### PR TITLE
Don't totally brick windows, just sorta brick it.

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: run tox
         run: python -m tox --skip-missing-interpreters=true
 
+  # no ssh2 for windows python3.8, so just peeling this out into its own job for now
   build_windows:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v1
@@ -24,3 +24,23 @@ jobs:
       - name: run tox
         run: python -m tox --skip-missing-interpreters=true
 
+  build_windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        os: [windows-latest]
+        python-version: [3.8]
+    steps:
+      - uses: actions/checkout@v1
+      - name: set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: setup test env
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools
+          python -m pip install tox
+      - name: run tox
+        run: python -m tox -e py37

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ with IOSXEDriver(**my_device) as conn:
 `pip install scrapli[textfsm]`
 
 
-# Cisco Genie Integration
+## Cisco Genie Integration
 
 Very much the same as the textfsm/ntc-templates integration, scrapli has optional integration with Cisco's PyATS
 /Genie parsing library for parsing show command output. While it is possible there are/will be parsers for non-Cisco

--- a/README.md
+++ b/README.md
@@ -153,13 +153,12 @@ This led to moving back to paramiko, which of course is a fantastic project with
    Paramiko - ControlPersist in particular is very interesting to me.
 
 With the goal of supporting all of the OpenSSH configuration options the primary transport driver option is simply
- native system local SSH (almost certainly this won't work on Windows, but I don't have a Windows box to test on, or
-  any particular interest in doing so). The implementation of using system SSH is of course a little bit messy
-  , however scrapli takes care of that for you so you don't need to care about it! The payoff of using system SSH is of
-   course that OpenSSH config files simply "work" -- no passing it to scrapli, no selective support, no need to set
-    username or ports or any of the other config items that may reside in your SSH config file. This driver
-      will likely be the focus of most development for this project, though I will try to keep the other transport
-       drivers -- in particular ssh2-python -- as close to parity as is possible/practical.
+ native system local SSH. The implementation of using system SSH is of course a little bit messy, however scrapli
+  takes care of that for you so you don't need to care about it! The payoff of using system SSH is of course that
+   OpenSSH config files simply "work" -- no passing it to scrapli, no selective support, no need to set username or
+    ports or any of the other config items that may reside in your SSH config file. This driver will likely be the
+     focus of most development for this project, though I will try to keep the other transport drivers -- in
+      particular ssh2-python -- as close to parity as is possible/practical.
 
 The last transport is telnet via telnetlib. This was trivial to add in as the interface is basically the same as
  SystemSSH, and it turns out telnet is still actually useful for things like terminal servers and the like!
@@ -271,7 +270,9 @@ The available optional installation extras options are:
 - textfsm (textfsm and ntc-templates)
 
 As for platforms to *run* scrapli on -- it has and will be tested on MacOS and Ubuntu regularly and should work on any
- POSIX system. Windows is *NOT* tested and will not be supported (officially at least, it may work... not really sure).
+ POSIX system. Windows is now being tested very minimally via GitHub Actions builds, however it is important to note
+  that if you wish to use Windows you will need to use paramiko or ssh2-python as the transport driver. It is
+   *strongly* recommended/preferred for folks to use WSL/Cygwin and stick with "systemssh" as the transport. 
 
 
 # Basic Usage
@@ -891,8 +892,7 @@ with GenericDriver(**my_device) as conn:
 scrapli is built to be very flexible, including being flexible enough to use different libraries for "transport
 " -- or the actual Telnet/SSH communication. By default scrapli uses the "system" transport which quite literally
  uses the ssh binary on your system (`/usr/bin/ssh`). This "system" transport means that scrapli has no external
-  dependencies as it just relies on what is available on the machine running the scrapli script. It also means that
-   scrapli by default probably(?) doesn't support Windows.
+  dependencies as it just relies on what is available on the machine running the scrapli script.
 
 In the spirit of being highly flexible, scrapli allows users to swap out this "system" transport with another
  transport mechanism. The other supported transport mechanisms are `paramiko`, `ssh2-python` and `telnetlib`. The
@@ -983,10 +983,13 @@ Currently the only reason I can think of to use anything other than "system" as 
  of ssh2-python (as of January 2020). GitHub user [Red-M](https://github.com/Red-M) has contributed to and fixed this
   particular issue but the fix has not been merged. If you would like to use ssh2-python with EOS I suggest cloning
    and installing via Red-M's repository or my fork of Red-M's fork!
+  - Windows users using python3.8 may need to use Red-M's fork, quick testing in GitHub actions for py3.8 on Windows
+   had install failures for ssh2-python.
 - Use the context manager where possible! More testing needs to be done to confirm/troubleshoot, but limited testing
  seems to indicate that without properly closing the connection there appears to be a bug that causes Python to crash
   on MacOS at least. More to come on this as I have time to poke it more! I believe this is only occurring on the
-   latest branch/update (i.e. not on the pip installable version).
+   latest branch/update (i.e. not on the pip installable version). (April 2020 -- this may be fixed... need to retest
+   ...)
 
 ## system
 
@@ -995,6 +998,9 @@ Currently the only reason I can think of to use anything other than "system" as 
   these cli arguments take precedence over the config file arguments.
 - If you set `ssh_config_file` to `False` the `SystemSSHTransport` class will set the config file used to `/dev/null
 ` so that no ssh config file configs are accidentally used.
+- There is zero Windows support for system ssh transport - I would strongly encourage the use of WSL or cygwin and
+ sticking with systemssh instead of using paramiko/ssh2 natively in Windows -- system ssh is very much the focus of
+  development for scrapli!
 
 ### SSH Config Supported Arguments
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ pycodestyle>=2.5.0
 pydocstyle>=5.0.2
 pylint>=2.4.4
 darglint>=1.2.0
-pdoc3>=0.7.5
+pdoc3>=0.7.5 ; sys_platform != 'win32'
 netmiko>=2.4.1
 napalm>=2.5.0
 -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ pycodestyle>=2.5.0
 pydocstyle>=5.0.2
 pylint>=2.4.4
 darglint>=1.2.0
-pdoc3>=0.7.5 ; sys_platform != 'win32'
+pdoc3>=0.7.5 ; sys_platform != "win32"
 netmiko>=2.4.1
 napalm>=2.5.0
 -r requirements.txt

--- a/requirements-genie.txt
+++ b/requirements-genie.txt
@@ -1,2 +1,2 @@
-genie>=20.2
-pyats>=20.2
+genie>=20.2 ; sys_platform != 'win32'
+pyats>=20.2 ; sys_platform != 'win32'

--- a/requirements-genie.txt
+++ b/requirements-genie.txt
@@ -1,2 +1,2 @@
-genie>=20.2 ; sys_platform != 'win32'
-pyats>=20.2 ; sys_platform != 'win32'
+genie>=20.2 ; sys_platform != "win32"
+pyats>=20.2 ; sys_platform != "win32"

--- a/requirements-ssh2.txt
+++ b/requirements-ssh2.txt
@@ -1,1 +1,1 @@
-ssh2-python>=0.18.0-1  ; sys_platform != "win32" and python_version == "3.8"
+ssh2-python>=0.18.0-1

--- a/requirements-ssh2.txt
+++ b/requirements-ssh2.txt
@@ -1,1 +1,1 @@
-ssh2-python>=0.18.0-1
+ssh2-python>=0.18.0-1  ; sys_platform != "win32" and python_version == "3.8"

--- a/scrapli/transport/ptyprocess.py
+++ b/scrapli/transport/ptyprocess.py
@@ -21,17 +21,12 @@ has been ridiculously helpful! -CM
 
 import builtins
 import errno
-import fcntl
 import io
 import os
-import pty
-import resource
 import signal
 import struct
 import sys
-import termios
 import time
-from pty import CHILD, STDIN_FILENO
 from shutil import which
 from typing import Type, TypeVar
 
@@ -55,6 +50,8 @@ def _make_eof_intr():
 
     This avoids doing potentially costly operations on module load.
     """
+    import termios
+
     global _EOF, _INTR
     if (_EOF is not None) and (_INTR is not None):
         return
@@ -94,6 +91,8 @@ def _make_eof_intr():
 
 
 def _setecho(fd, state):
+    import termios
+
     errmsg = "setecho() may not be called on this platform (it may still be possible to enable/disable echo when spawning the child process)"
 
     try:
@@ -123,6 +122,9 @@ def _setwinsize(fd, rows, cols):
     # termios.TIOCSWINSZ to be truncated. There was a hack here to work
     # around this, but it caused problems with newer platforms so has been
     # removed. For details see https://github.com/pexpect/pexpect/issues/39
+    import termios
+    import fcntl
+
     TIOCSWINSZ = getattr(termios, "TIOCSWINSZ", -2146929561)
     # Note, assume ws_xpixel and ws_ypixel are zero.
     s = struct.pack("HHHH", rows, cols, 0, 0)
@@ -208,6 +210,12 @@ class PtyProcess(object):
         # EOF immediately then it means that the child is already dead.
         # That may not necessarily be bad because you may have spawned a child
         # that performs some task; creates no stdout output; and then dies.
+
+        import fcntl
+        import pty
+        import termios
+        import resource
+        from pty import CHILD, STDIN_FILENO
 
         if not isinstance(argv, (list, tuple)):
             raise TypeError("Expected a list or tuple for argv, got %r" % argv)

--- a/scrapli/transport/systemssh.py
+++ b/scrapli/transport/systemssh.py
@@ -1,6 +1,5 @@
 """scrapli.transport.systemssh"""
 import os
-import pty
 import re
 from logging import getLogger
 from select import select
@@ -294,6 +293,10 @@ class SystemSSHTransport(Transport):
             N/A
 
         """
+        # import here so that we dont blow up when running on windows (windows users need to use
+        #  ssh2 or paramiko transport)
+        import pty  # pylint: disable=C0415
+
         # copy the open_cmd as we don't want to update the objects open_cmd until we know we can
         # authenticate. add verbose output and disable batch mode (disables passphrase/password
         # queries). If auth is successful update the object open_cmd to represent what was used

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 __author__ = "Carl Montanari"
 
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="utf-8") as f:
     README = f.read()
 
 setuptools.setup(

--- a/tests/unit/driver/test_driver.py
+++ b/tests/unit/driver/test_driver.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -184,6 +185,7 @@ def test_valid_private_key_file():
     )
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not currently testing ssh file resolution on windows")
 @pytest.mark.parametrize(
     "ssh_file",
     [

--- a/tests/unit/driver/test_network_driver.py
+++ b/tests/unit/driver/test_network_driver.py
@@ -1,3 +1,4 @@
+import sys
 import types
 
 import pytest
@@ -452,6 +453,7 @@ def test_send_configs(mocked_network_driver):
     assert output[0].result == channel_output_5
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting textfsm on windows")
 @pytest.mark.skipif(textfsm_avail is False, reason="textfsm and/or ntc_templates are not installed")
 @pytest.mark.parametrize(
     "parse_type",

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -62,6 +62,7 @@ def test__textfsm_get_template_valid_template():
     assert template.name == f"{template_dir}/cisco_nxos_show_ip_arp.textfsm"
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting textfsm on windows")
 def test__textfsm_get_template_invalid_template():
     template = _textfsm_get_template("cisco_nxos", "show racecar")
     assert not template
@@ -130,6 +131,7 @@ def test_textfsm_parse_failure():
     assert result == []
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting genie on windows")
 def test_genie_parse_success():
     result = genie_parse("iosxe", "show ip arp", IOS_ARP)
     assert isinstance(result, dict)
@@ -138,6 +140,7 @@ def test_genie_parse_success():
     )
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting genie on windows")
 def test_genie_parse_failure():
     result = genie_parse("iosxe", "show ip arp", "not really arp data")
     assert result == []

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -119,6 +119,7 @@ Internet  172.31.254.2            -   c800.84b2.e9c2  ARPA   Vlan254
     )
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting genie on windows")
 def test_response_parse_genie_fail():
     response = Response("localhost", channel_input="show ip arp", genie_platform="iosxe")
     response_str = ""

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime
 
 import pytest
@@ -65,6 +66,7 @@ drwxr-xr-x  12 carl  staff    384 Jan 27 19:13 .git/"""
     assert response.failed is False
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting textfsm on windows")
 @pytest.mark.parametrize(
     "parse_type",
     [
@@ -95,6 +97,7 @@ Internet  172.31.254.2            -   c800.84b2.e9c2  ARPA   Vlan254
     assert response.textfsm_parse_output(to_dict=to_dict)[0] == expected_result
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting textfsm on windows")
 def test_response_parse_textfsm_fail():
     response = Response("localhost", channel_input="show ip arp", textfsm_platform="cisco_ios")
     response_str = ""
@@ -102,6 +105,7 @@ def test_response_parse_textfsm_fail():
     assert response.textfsm_parse_output() == []
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting genie on windows")
 def test_response_parse_genie():
     response = Response("localhost", channel_input="show ip arp", genie_platform="iosxe")
     response_str = """Protocol  Address          Age (min)  Hardware Addr   Type   Interface

--- a/tests/unit/test_ssh_config.py
+++ b/tests/unit/test_ssh_config.py
@@ -1,5 +1,8 @@
 import os
+import sys
 from pathlib import Path
+
+import pytest
 
 import scrapli
 from scrapli.ssh_config import Host, SSHConfig, SSHKnownHosts
@@ -12,6 +15,7 @@ def test_str():
     assert str(ssh_conf) == "SSHConfig Object"
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not currently testing ssh file resolution on windows")
 def test_repr():
     ssh_conf = SSHConfig(f"{UNIT_TEST_DIR}_ssh_config")
     assert repr(ssh_conf) == (
@@ -47,6 +51,7 @@ def test_host__str():
     assert str(host) == "Host: "
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not currently testing ssh file resolution on windows")
 def test_host__repr():
     ssh_conf = SSHConfig(f"{UNIT_TEST_DIR}_ssh_config")
     assert repr(ssh_conf.hosts["1.2.3.4 someswitch1"]) == (
@@ -100,6 +105,7 @@ def test_init_ssh_config_file_no_hosts():
     assert ssh_conf.hosts["*"].preferred_authentication is None
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not currently testing ssh file resolution on windows")
 def test_host_lookup_exact_host():
     ssh_conf = SSHConfig(f"{UNIT_TEST_DIR}_ssh_config")
     host = ssh_conf.lookup("1.2.3.4 someswitch1")
@@ -112,6 +118,7 @@ def test_host_lookup_exact_host():
     )
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not currently testing ssh file resolution on windows")
 def test_host_lookup_exact_host_in_list():
     ssh_conf = SSHConfig(f"{UNIT_TEST_DIR}_ssh_config")
     host = ssh_conf.lookup("someswitch1")
@@ -124,6 +131,7 @@ def test_host_lookup_exact_host_in_list():
     )
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not currently testing ssh file resolution on windows")
 def test_host_lookup_host_fuzzy():
     ssh_conf = SSHConfig(f"{UNIT_TEST_DIR}_ssh_config")
     host = ssh_conf.lookup("someswitch2")
@@ -136,6 +144,7 @@ def test_host_lookup_host_fuzzy():
     )
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not currently testing ssh file resolution on windows")
 def test_host_lookup_host_fuzzy_multi_match():
     ssh_conf = SSHConfig(f"{UNIT_TEST_DIR}_ssh_config")
     host = ssh_conf.lookup("someswitch9999")

--- a/tests/unit/transport/test_cssh2.py
+++ b/tests/unit/transport/test_cssh2.py
@@ -1,6 +1,11 @@
+import sys
+
+import pytest
+
 from scrapli.transport import SSH2Transport
 
 
+@pytest.mark.skipif((sys.platform.startswith("win") and sys.version_info > (3, 7)), reason="ssh2 on pypi not built for python3.8 on windows")
 def test_creation():
     conn = SSH2Transport("localhost")
     assert conn.host == "localhost"

--- a/tests/unit/transport/test_socket.py
+++ b/tests/unit/transport/test_socket.py
@@ -1,15 +1,19 @@
+import sys
+
 import pytest
 
 from scrapli.exceptions import ScrapliTimeout
 from scrapli.transport.socket import Socket
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not testing windows")
 def test_socket_open_success():
     sock = Socket("localhost", 22, 1)
     sock.socket_open()
     assert sock.socket_isalive() is True
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not testing windows")
 def test_socket_open_failure_connection_refused():
     sock = Socket("localhost", 2222, 1)
     with pytest.raises(ConnectionRefusedError) as e:
@@ -17,6 +21,7 @@ def test_socket_open_failure_connection_refused():
     assert str(e.value) == "Connection refused trying to open socket to localhost on port 2222"
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not testing windows")
 def test_socket_open_failure_timeout():
     sock = Socket("240.0.0.1", 22, 0.1)
     with pytest.raises(ScrapliTimeout) as e:
@@ -24,6 +29,7 @@ def test_socket_open_failure_timeout():
     assert str(e.value) == "Timed out trying to open socket to 240.0.0.1 on port 22"
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="not testing windows")
 def test_socket_close_success():
     sock = Socket("localhost", 22, 1)
     sock.socket_open()

--- a/tests/unit/transport/test_systemssh.py
+++ b/tests/unit/transport/test_systemssh.py
@@ -1,6 +1,11 @@
+import sys
+
+import pytest
+
 from scrapli.transport import SystemSSHTransport
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="systemssh not supported on windows")
 def test_creation():
     conn = SystemSSHTransport("localhost")
     assert conn.host == "localhost"


### PR DESCRIPTION
- move imports around to *not* blow up when running scrapli on windows
- adjust tests to skip a bunch of stuff im not going to bother testing for windows
