### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ CHANGELOG
 - Made the `get_prompt_pattern` helper a little worse... should revisit to improve/make its use more clear
 - Fixed a screw up that had ridiculous transport timeouts -- at one point timeouts were in seconds, then milliseconds
 ... went back to seconds, but left things setting millisecond values... fixed :D 
+- Added `transport_options` to base `Scrape` class -- this is a dict of arguments that can be passed down to your
+ selected transport class... for now this is very limited and is just for passing additional "open_cmd" arguments to
+  `SystemSSHTransport`. The current use case is adding args such as ciphers/kex to your ssh command so you don't need
+   to rely on having this in an ssh config file.
 
 # 2020.04.19
 - Increase character count for base prompt pattern for `Scrape`, `GenericDriver`, and core drivers. Example:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ CHANGELOG
  to be here in the base `Transport` class as the issue affected all transport types
 - Added `send_commands_from_file` method... does what it sounds like it does...
 - Added `send_configs_from_file` method (`NetworkDriver` and sub-classes)... also does what it sounds like it does
+- Simplified privilege levels and overhauled how auth escalation/deescalation works. Its still probably a bit more
+ complex than it should be, but its a bit more efficient and at least a little simpler/more flexible.
+- Removed `comms_prompt_pattern` from Network drivers and now build this as a big pattern matching all of the priv
+ levels for that device type. This is used only for initial connection/finding prompt then scrapli still sets the
+  explicit prompt for the particular privilege level.
+- Implemented lru_cache on some places where we have repetitive tasks... probably unmeasurable difference, but in
+ theory its a little faster now in some places
+- Moved some Network driver things into the  base `NetworkDriver` class to clean things up a bit.
+- Added an `_abort_config` method to abort configurations for IOSXR/Juniper, this is ignored on the other core platforms
+- *BREAKING CHANGE*: (minor) Removed now unneeded exception `CouldNotAcquirePrivLevel`
+- Made the `get_prompt_pattern` helper a little worse... should revisit to improve/make its use more clear
 
 # 2020.04.19
 - Increase character count for base prompt pattern for `Scrape`, `GenericDriver`, and core drivers. Example:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =======
 
+# 2020.XX.XX
+- Continued improvement around `SystemSSHTransport` connection/auth failure logging
+- Fix for very intermittent issue where pty fd is not available for reading on SystemSSH/Telnet connections, now we
+ loop over the select statement checking the fd instead of failing if it isn't immediately readable
+- Implement atexit function if keepalives are enabled -- this originally just lived in the ssh2 transport, but needs
+ to be here in the base `Transport` class as the issue affected all transport types
+- Added `send_commands_from_file` method... does what it sounds like it does...
+- Added `send_configs_from_file` method (`NetworkDriver` and sub-classes)... also does what it sounds like it does
+
 # 2020.04.19
 - Increase character count for base prompt pattern for `Scrape`, `GenericDriver`, and core drivers. Example:
 `r"^[a-z0-9.\-@()/:]{1,32}[#>$]$"` for the base `IOSXEDriver` `comms_prompt_pattern` has been increased to:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ CHANGELOG
 - Added an `_abort_config` method to abort configurations for IOSXR/Juniper, this is ignored on the other core platforms
 - *BREAKING CHANGE*: (minor) Removed now unneeded exception `CouldNotAcquirePrivLevel`
 - Made the `get_prompt_pattern` helper a little worse... should revisit to improve/make its use more clear
+- Fixed a screw up that had ridiculous transport timeouts -- at one point timeouts were in seconds, then milliseconds
+... went back to seconds, but left things setting millisecond values... fixed :D 
 
 # 2020.04.19
 - Increase character count for base prompt pattern for `Scrape`, `GenericDriver`, and core drivers. Example:

--- a/docs/PUBLIC_API_STATUS.md
+++ b/docs/PUBLIC_API_STATUS.md
@@ -28,6 +28,7 @@
 | acquire_priv                 | 2020.03.29  |             |                                                           |
 | send_command                 | 2020.03.29  |             |                                                           |
 | send_commands                | 2020.03.29  |             |                                                           |
+| send_commands_from_file      | 2020.04.XX  |             |                                                           |
 | send_configs                 | 2020.03.29  |             |                                                           |
 | send_configs_from_file       | 2020.04.XX  |             |                                                           |
                           

--- a/docs/PUBLIC_API_STATUS.md
+++ b/docs/PUBLIC_API_STATUS.md
@@ -17,6 +17,7 @@
 | get_prompt                   | 2020.03.29  |             |                                                           |
 | send_command                 | 2020.03.29  |             |                                                           |
 | send_commands                | 2020.03.29  |             |                                                           |
+| send_commands_from_file      | 2020.04.XX  |             |                                                           |
 | send_interactive             | 2020.03.29  | 2020.04.11  | changed to support list of "events" to interact with      |
 
 
@@ -28,6 +29,7 @@
 | send_command                 | 2020.03.29  |             |                                                           |
 | send_commands                | 2020.03.29  |             |                                                           |
 | send_configs                 | 2020.03.29  |             |                                                           |
+| send_configs_from_file       | 2020.04.XX  |             |                                                           |
                           
 
 ## Channel

--- a/examples/transport_options/system_ssh_args.py
+++ b/examples/transport_options/system_ssh_args.py
@@ -1,0 +1,27 @@
+"""examples.transport_options.system_ssh_args"""
+from scrapli.driver.core import IOSXEDriver
+
+MY_DEVICE = {
+    "host": "172.18.0.11",
+    "auth_username": "vrnetlab",
+    "auth_password": "VR-netlab9",
+    "auth_strict_key": False,
+    "transport_options": {"open_cmd": ["-o", "KexAlgorithms=+diffie-hellman-group1-sha1"]},
+}
+
+
+def main():
+    """Simple example demonstrating adding transport options"""
+    conn = IOSXEDriver(**MY_DEVICE)
+    # with the transport options provided, we can extend the open command to include extra args
+    print(conn.transport.open_cmd)
+
+    # deleting the transport options we can see what the default open command would look like
+    MY_DEVICE.pop("transport_options")
+    del conn
+    conn = IOSXEDriver(**MY_DEVICE)
+    print(conn.transport.open_cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ pylama>=7.7.1
 pycodestyle>=2.5.0
 pydocstyle>=5.0.2
 pylint>=2.4.4
-darglint>=1.2.2
+darglint>=1.2.3
 pdoc3>=0.7.5 ; sys_platform != "win32"
 napalm>=2.5.0
 -r requirements.txt

--- a/scrapli/channel/channel.py
+++ b/scrapli/channel/channel.py
@@ -233,7 +233,7 @@ class Channel:
 
         """
         prompt_pattern = get_prompt_pattern(prompt="", class_prompt=self.comms_prompt_pattern)
-        self.transport.set_timeout(timeout=1000)
+        self.transport.set_timeout(timeout=10)
         self._send_return()
         output = b""
         while True:

--- a/scrapli/driver/community/__init__.py
+++ b/scrapli/driver/community/__init__.py
@@ -1,1 +1,0 @@
-"""scrapli.driver.community"""

--- a/scrapli/driver/core/arista_eos/driver.py
+++ b/scrapli/driver/core/arista_eos/driver.py
@@ -18,7 +18,7 @@ def eos_on_open(conn: NetworkDriver) -> None:
     Raises:
         N/A
     """
-    conn.acquire_priv(desired_priv=conn.default_desired_priv)
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.channel.send_input(channel_input="terminal length 0")
     conn.channel.send_input(channel_input="terminal width 32767")
 
@@ -38,65 +38,33 @@ def eos_on_close(conn: NetworkDriver) -> None:
     """
     # write exit directly to the transport as channel would fail to find the prompt after sending
     # the exit command!
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.transport.write(channel_input="exit")
     conn.transport.write(channel_input=conn.channel.comms_prompt_pattern)
 
 
 PRIVS = {
-    "exec": (
-        PrivilegeLevel(
-            r"^[a-z0-9.\-@()/:]{1,32}>\s?$",
-            "exec",
-            "",
-            "",
-            "privilege_exec",
-            "enable",
-            True,
-            "Password:",
-            True,
-            0,
-        )
-    ),
+    "exec": (PrivilegeLevel(r"^[a-z0-9.\-@()/:]{1,32}>\s?$", "exec", "", "", "", False, "",)),
     "privilege_exec": (
         PrivilegeLevel(
             r"^[a-z0-9.\-@/:]{1,32}#\s?$",
             "privilege_exec",
             "exec",
             "disable",
-            "configuration",
-            "configure terminal",
-            False,
-            "",
+            "enable",
             True,
-            1,
+            "Password:",
         )
     ),
     "configuration": (
         PrivilegeLevel(
-            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{0,16}\)#\s?$",
+            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{0,32}\)#\s?$",
             "configuration",
             "privilege_exec",
             "end",
-            "",
-            "",
+            "configure terminal",
             False,
             "",
-            True,
-            2,
-        )
-    ),
-    "special_configuration": (
-        PrivilegeLevel(
-            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{1,16}\)#\s?$",
-            "special_configuration",
-            "privilege_exec",
-            "end",
-            "",
-            "",
-            False,
-            "",
-            False,
-            3,
         )
     ),
 }
@@ -105,7 +73,6 @@ PRIVS = {
 class EOSDriver(NetworkDriver):
     def __init__(
         self,
-        comms_prompt_pattern: str = r"^[a-z0-9.\-@()/:]{1,48}[#>$]\s?$",
         on_open: Optional[Callable[..., Any]] = None,
         on_close: Optional[Callable[..., Any]] = None,
         auth_secondary: str = "",
@@ -115,14 +82,6 @@ class EOSDriver(NetworkDriver):
         EOSDriver Object
 
         Args:
-            comms_prompt_pattern: raw string regex pattern -- preferably use `^` and `$` anchors!
-                this is the single most important attribute here! if this does not match a prompt,
-                scrapli will not work!
-                IMPORTANT: regex search uses multi-line + case insensitive flags. multi-line allows
-                for highly reliably matching for prompts however we do NOT strip trailing whitespace
-                for each line, so be sure to add '\\s*' if your device needs that. This should be
-                mostly sorted for you if using network drivers (i.e. `IOSXEDriver`). Lastly, the
-                case insensitive is just a convenience factor so i can be lazy.
             on_open: callable that accepts the class instance as its only argument. this callable,
                 if provided, is executed immediately after authentication is completed. Common use
                 cases for this callable would be to disable paging or accept any kind of banner
@@ -146,15 +105,14 @@ class EOSDriver(NetworkDriver):
             on_close = eos_on_close
 
         super().__init__(
+            privilege_levels=PRIVS,
+            default_desired_privilege_level="privilege_exec",
             auth_secondary=auth_secondary,
-            comms_prompt_pattern=comms_prompt_pattern,
             on_open=on_open,
             on_close=on_close,
             **kwargs,
         )
 
-        self.privs = PRIVS
-        self.default_desired_priv = "privilege_exec"
         self.textfsm_platform = "arista_eos"
 
         self.failed_when_contains = [

--- a/scrapli/driver/core/cisco_iosxe/driver.py
+++ b/scrapli/driver/core/cisco_iosxe/driver.py
@@ -18,7 +18,7 @@ def iosxe_on_open(conn: NetworkDriver) -> None:
     Raises:
         N/A
     """
-    conn.acquire_priv(desired_priv=conn.default_desired_priv)
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.channel.send_input(channel_input="terminal length 0")
     conn.channel.send_input(channel_input="terminal width 512")
 
@@ -38,65 +38,44 @@ def iosxe_on_close(conn: NetworkDriver) -> None:
     """
     # write exit directly to the transport as channel would fail to find the prompt after sending
     # the exit command!
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.transport.write(channel_input="exit")
     conn.transport.write(channel_input=conn.channel.comms_prompt_pattern)
 
 
 PRIVS = {
-    "exec": (
-        PrivilegeLevel(
-            r"^[a-z0-9.\-@()/:]{1,32}>$",
-            "exec",
-            "",
-            "",
-            "privilege_exec",
-            "enable",
-            True,
-            "Password:",
-            True,
-            0,
-        )
-    ),
+    "exec": (PrivilegeLevel(r"^[a-z0-9.\-@()/:]{1,32}>$", "exec", "", "", "", False, "",)),
     "privilege_exec": (
         PrivilegeLevel(
             r"^[a-z0-9.\-@/:]{1,32}#$",
             "privilege_exec",
             "exec",
             "disable",
-            "configuration",
-            "configure terminal",
-            False,
-            "",
+            "enable",
             True,
-            1,
+            "Password:",
         )
     ),
     "configuration": (
         PrivilegeLevel(
-            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{0,16}\)#$",
+            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{0,32}\)#$",
             "configuration",
             "privilege_exec",
             "end",
-            "",
-            "",
+            "configure terminal",
             False,
             "",
-            True,
-            2,
         )
     ),
-    "special_configuration": (
+    "configuration_exclusive": (
         PrivilegeLevel(
-            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{1,16}\)#$",
-            "special_configuration",
+            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{0,32}\)#$",
+            "configuration_exclusive",
             "privilege_exec",
             "end",
-            "",
-            "",
+            "configure exclusive",
             False,
             "",
-            False,
-            3,
         )
     ),
 }
@@ -105,7 +84,6 @@ PRIVS = {
 class IOSXEDriver(NetworkDriver):
     def __init__(
         self,
-        comms_prompt_pattern: str = r"^[a-z0-9.\-@()/:]{1,48}[#>$]$",
         on_open: Optional[Callable[..., Any]] = None,
         on_close: Optional[Callable[..., Any]] = None,
         auth_secondary: str = "",
@@ -115,14 +93,6 @@ class IOSXEDriver(NetworkDriver):
         IOSXEDriver Object
 
         Args:
-            comms_prompt_pattern: raw string regex pattern -- preferably use `^` and `$` anchors!
-                this is the single most important attribute here! if this does not match a prompt,
-                scrapli will not work!
-                IMPORTANT: regex search uses multi-line + case insensitive flags. multi-line allows
-                for highly reliably matching for prompts however we do NOT strip trailing whitespace
-                for each line, so be sure to add '\\s*' if your device needs that. This should be
-                mostly sorted for you if using network drivers (i.e. `IOSXEDriver`). Lastly, the
-                case insensitive is just a convenience factor so i can be lazy.
             on_open: callable that accepts the class instance as its only argument. this callable,
                 if provided, is executed immediately after authentication is completed. Common use
                 cases for this callable would be to disable paging or accept any kind of banner
@@ -146,15 +116,13 @@ class IOSXEDriver(NetworkDriver):
             on_close = iosxe_on_close
 
         super().__init__(
+            privilege_levels=PRIVS,
+            default_desired_privilege_level="privilege_exec",
             auth_secondary=auth_secondary,
-            comms_prompt_pattern=comms_prompt_pattern,
             on_open=on_open,
             on_close=on_close,
             **kwargs,
         )
-
-        self.privs = PRIVS
-        self.default_desired_priv = "privilege_exec"
 
         self.textfsm_platform = "cisco_ios"
         self.genie_platform = "iosxe"

--- a/scrapli/driver/core/cisco_iosxr/driver.py
+++ b/scrapli/driver/core/cisco_iosxr/driver.py
@@ -43,7 +43,7 @@ def iosxr_on_close(conn: NetworkDriver) -> None:
     # write exit directly to the transport as channel would fail to find the prompt after sending
     # the exit command!
     conn.transport.write(channel_input="exit")
-    conn.transport.write(channel_input=conn.channel.comms_prompt_pattern)
+    conn.transport.write(channel_input=conn.channel.comms_return_char)
 
 
 PRIVS = {

--- a/scrapli/driver/core/cisco_iosxr/driver.py
+++ b/scrapli/driver/core/cisco_iosxr/driver.py
@@ -22,7 +22,7 @@ def iosxr_on_open(conn: NetworkDriver) -> None:
     # sleep for session to establish; without this we never find base prompt for some reason?
     # maybe this is an artifact from previous iterations/tests and can be done away with...
     time.sleep(1)
-    conn.acquire_priv(desired_priv=conn.default_desired_priv)
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.channel.send_input(channel_input="terminal length 0")
     conn.channel.send_input(channel_input="terminal width 512")
 
@@ -42,51 +42,35 @@ def iosxr_on_close(conn: NetworkDriver) -> None:
     """
     # write exit directly to the transport as channel would fail to find the prompt after sending
     # the exit command!
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.transport.write(channel_input="exit")
     conn.transport.write(channel_input=conn.channel.comms_return_char)
 
 
 PRIVS = {
     "privilege_exec": (
-        PrivilegeLevel(
-            r"^[a-z0-9.\-@/:]{1,32}#\s?$",
-            "privilege_exec",
-            "exec",
-            "disable",
-            "configuration",
-            "configure terminal",
-            False,
-            "",
-            True,
-            1,
-        )
+        PrivilegeLevel(r"^[a-z0-9.\-@/:]{1,32}#\s?$", "privilege_exec", "", "", "", False, "",)
     ),
     "configuration": (
         PrivilegeLevel(
-            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{0,16}\)#\s?$",
+            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{0,32}\)#\s?$",
             "configuration",
             "privilege_exec",
             "end",
-            "",
-            "",
+            "configure terminal",
             False,
             "",
-            True,
-            2,
         )
     ),
-    "special_configuration": (
+    "configuration_exclusive": (
         PrivilegeLevel(
-            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{1,16}\)#\s?$",
-            "special_configuration",
+            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{1,32}\)#\s?$",
+            "configuration_exclusive",
             "privilege_exec",
             "end",
-            "",
-            "",
+            "configure exclusive",
             False,
             "",
-            False,
-            3,
         )
     ),
 }
@@ -95,7 +79,6 @@ PRIVS = {
 class IOSXRDriver(NetworkDriver):
     def __init__(
         self,
-        comms_prompt_pattern: str = r"^[a-z0-9.\-@/:]{1,48}#\s?$",
         on_open: Optional[Callable[..., Any]] = None,
         on_close: Optional[Callable[..., Any]] = None,
         auth_secondary: str = "",
@@ -105,14 +88,6 @@ class IOSXRDriver(NetworkDriver):
         IOSXRDriver Object
 
         Args:
-            comms_prompt_pattern: raw string regex pattern -- preferably use `^` and `$` anchors!
-                this is the single most important attribute here! if this does not match a prompt,
-                scrapli will not work!
-                IMPORTANT: regex search uses multi-line + case insensitive flags. multi-line allows
-                for highly reliably matching for prompts however we do NOT strip trailing whitespace
-                for each line, so be sure to add '\\s*' if your device needs that. This should be
-                mostly sorted for you if using network drivers (i.e. `IOSXEDriver`). Lastly, the
-                case insensitive is just a convenience factor so i can be lazy.
             on_open: callable that accepts the class instance as its only argument. this callable,
                 if provided, is executed immediately after authentication is completed. Common use
                 cases for this callable would be to disable paging or accept any kind of banner
@@ -136,15 +111,13 @@ class IOSXRDriver(NetworkDriver):
             on_close = iosxr_on_close
 
         super().__init__(
+            privilege_levels=PRIVS,
+            default_desired_privilege_level="privilege_exec",
             auth_secondary=auth_secondary,
-            comms_prompt_pattern=comms_prompt_pattern,
             on_open=on_open,
             on_close=on_close,
             **kwargs,
         )
-
-        self.privs = PRIVS
-        self.default_desired_priv = "privilege_exec"
 
         self.textfsm_platform = "cisco_xr"
         self.genie_platform = "iosxr"
@@ -154,3 +127,22 @@ class IOSXRDriver(NetworkDriver):
             "% Incomplete command",
             "% Invalid input detected",
         ]
+
+    def _abort_config(self) -> None:
+        """
+        Abort IOSXR configuration session
+
+        Args:
+            N/A
+
+        Returns:
+            N/A:  # noqa: DAR202
+
+        Raises:
+            N/A
+
+        """
+        self.channel.comms_prompt_pattern = self.privilege_levels[
+            self.default_desired_privilege_level
+        ].pattern
+        self.channel.send_input(channel_input="abort")

--- a/scrapli/driver/core/cisco_nxos/driver.py
+++ b/scrapli/driver/core/cisco_nxos/driver.py
@@ -18,6 +18,7 @@ def nxos_on_open(conn: NetworkDriver) -> None:
     Raises:
         N/A
     """
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.channel.send_input(channel_input="terminal length 0")
     conn.channel.send_input(channel_input="terminal width 511")
 
@@ -37,66 +38,33 @@ def nxos_on_close(conn: NetworkDriver) -> None:
     """
     # write exit directly to the transport as channel would fail to find the prompt after sending
     # the exit command!
-    conn.acquire_priv(desired_priv=conn.default_desired_priv)
+    conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
     conn.transport.write(channel_input="exit")
     conn.transport.write(channel_input=conn.channel.comms_prompt_pattern)
 
 
 PRIVS = {
-    "exec": (
-        PrivilegeLevel(
-            r"^[a-z0-9.\-@()/:]{1,32}>\s?$",
-            "exec",
-            "",
-            "",
-            "privilege_exec",
-            "enable",
-            True,
-            "Password:",
-            True,
-            0,
-        )
-    ),
+    "exec": (PrivilegeLevel(r"^[a-z0-9.\-@()/:]{1,32}>\s?$", "exec", "", "", "", False, "",)),
     "privilege_exec": (
         PrivilegeLevel(
             r"^[a-z0-9.\-@/:]{1,32}#\s?$",
             "privilege_exec",
             "exec",
             "disable",
-            "configuration",
-            "configure terminal",
-            False,
-            "",
+            "enable",
             True,
-            1,
+            "Password:",
         )
     ),
     "configuration": (
         PrivilegeLevel(
-            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{0,16}\)#\s?$",
+            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{0,32}\)#\s?$",
             "configuration",
             "privilege_exec",
             "end",
-            "",
-            "",
+            "configure terminal",
             False,
             "",
-            True,
-            2,
-        )
-    ),
-    "special_configuration": (
-        PrivilegeLevel(
-            r"^[a-z0-9.\-@/:]{1,32}\(config[a-z0-9.\-@/:]{1,16}\)#\s?$",
-            "special_configuration",
-            "privilege_exec",
-            "end",
-            "",
-            "",
-            False,
-            "",
-            False,
-            3,
         )
     ),
 }
@@ -105,7 +73,6 @@ PRIVS = {
 class NXOSDriver(NetworkDriver):
     def __init__(
         self,
-        comms_prompt_pattern: str = r"^[a-z0-9.\-@()/:]{1,48}[#>$]\s?$",
         on_open: Optional[Callable[..., Any]] = None,
         on_close: Optional[Callable[..., Any]] = None,
         auth_secondary: str = "",
@@ -116,14 +83,6 @@ class NXOSDriver(NetworkDriver):
         NXOSDriver Object
 
         Args:
-            comms_prompt_pattern: raw string regex pattern -- preferably use `^` and `$` anchors!
-                this is the single most important attribute here! if this does not match a prompt,
-                scrapli will not work!
-                IMPORTANT: regex search uses multi-line + case insensitive flags. multi-line allows
-                for highly reliably matching for prompts however we do NOT strip trailing whitespace
-                for each line, so be sure to add `\\s*` if your device needs that. This should be
-                mostly sorted for you if using network drivers (i.e. `IOSXEDriver`). Lastly, the
-                case insensitive is just a convenience factor so i can be lazy.
             on_open: callable that accepts the class instance as its only argument. this callable,
                 if provided, is executed immediately after authentication is completed. Common use
                 cases for this callable would be to disable paging or accept any kind of banner
@@ -162,8 +121,9 @@ class NXOSDriver(NetworkDriver):
             _telnet = True
 
         super().__init__(
+            privilege_levels=PRIVS,
+            default_desired_privilege_level="privilege_exec",
             auth_secondary=auth_secondary,
-            comms_prompt_pattern=comms_prompt_pattern,
             on_open=on_open,
             on_close=on_close,
             transport=transport,
@@ -172,9 +132,6 @@ class NXOSDriver(NetworkDriver):
 
         if _telnet:
             self.transport.username_prompt = "login:"
-
-        self.privs = PRIVS
-        self.default_desired_priv = "privilege_exec"
 
         self.textfsm_platform = "cisco_nxos"
         self.genie_platform = "nxos"

--- a/scrapli/driver/core/cisco_nxos/driver.py
+++ b/scrapli/driver/core/cisco_nxos/driver.py
@@ -183,4 +183,5 @@ class NXOSDriver(NetworkDriver):
             "% Ambiguous command",
             "% Incomplete command",
             "% Invalid input detected",
+            "% Invalid command at",
         ]

--- a/scrapli/driver/core/juniper_junos/driver.py
+++ b/scrapli/driver/core/juniper_junos/driver.py
@@ -156,4 +156,5 @@ class JunosDriver(NetworkDriver):
             "is ambiguous.",
             "No valid completions",
             "unknown command.",
+            "syntax error, expecting",
         ]

--- a/scrapli/driver/driver.py
+++ b/scrapli/driver/driver.py
@@ -363,14 +363,14 @@ class Scrape:
         self._initialization_args["auth_password"] = auth_password.strip()
 
         if auth_private_key:
-            public_key_path = Path.expanduser(Path(auth_private_key.strip()))
-            if not public_key_path.is_file():
+            private_key_path = Path.expanduser(Path(auth_private_key.strip()))
+            if not private_key_path.is_file():
                 raise ValueError(f"Provided public key `{auth_private_key}` is not a file")
             self._initialization_args["auth_private_key"] = os.path.expanduser(
-                auth_private_key.strip().encode()
+                auth_private_key.strip()
             )
         else:
-            self._initialization_args["auth_private_key"] = auth_private_key.encode()
+            self._initialization_args["auth_private_key"] = auth_private_key
 
     def _setup_timeouts(
         self, timeout_socket: int, timeout_transport: int, timeout_ops: int, timeout_exit: bool

--- a/scrapli/driver/generic_driver.py
+++ b/scrapli/driver/generic_driver.py
@@ -137,20 +137,23 @@ class GenericDriver(Scrape):
         file: str,
         strip_prompt: bool = True,
         failed_when_contains: Optional[Union[str, List[str]]] = None,
+        stop_on_failed: bool = False,
     ) -> List[Response]:
         """
-        Send multiple commands
+        Send command(s) from file
 
         Args:
             file: string path to file
             strip_prompt: True/False strip prompt from returned output
             failed_when_contains: string or list of strings indicating failure if found in response
+            stop_on_failed: True/False stop executing commands if a command fails, returns results
+                as of current execution
 
         Returns:
             responses: list of Scrapli Response objects
 
         Raises:
-            TypeError: if commands is anything but a list
+            TypeError: if anything but a string is provided for `file`
 
         """
         if not isinstance(file, str):
@@ -162,17 +165,12 @@ class GenericDriver(Scrape):
         with open(resolved_file, "r") as f:
             commands = f.read().splitlines()
 
-        responses = []
-        for command in commands:
-            responses.append(
-                self.send_command(
-                    command=command,
-                    strip_prompt=strip_prompt,
-                    failed_when_contains=failed_when_contains,
-                )
-            )
-
-        return responses
+        return self.send_commands(
+            commands=commands,
+            strip_prompt=strip_prompt,
+            failed_when_contains=failed_when_contains,
+            stop_on_failed=stop_on_failed,
+        )
 
     def send_interactive(
         self,

--- a/scrapli/helper.py
+++ b/scrapli/helper.py
@@ -3,6 +3,7 @@ import importlib
 import os
 import re
 import warnings
+from functools import lru_cache
 from io import TextIOWrapper
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Pattern, TextIO, Tuple, Union
@@ -24,6 +25,7 @@ def _find_transport_plugin(transport: str) -> Tuple[Any, Tuple[str, ...]]:
         required_transport_args: tuple of required arguments for given transport
 
     Raises:
+        ModuleNotFoundError: if unable to  find scrapli transport module
         TransportPluginError: if unable to load `Transport` and `TRANSPORT_ARGS` from given
             transport module
 
@@ -48,6 +50,7 @@ def _find_transport_plugin(transport: str) -> Tuple[Any, Tuple[str, ...]]:
     return transport_class, required_transport_args
 
 
+@lru_cache()
 def get_prompt_pattern(prompt: str, class_prompt: str) -> Pattern[bytes]:
     """
     Return compiled prompt pattern
@@ -56,7 +59,7 @@ def get_prompt_pattern(prompt: str, class_prompt: str) -> Pattern[bytes]:
 
     Args:
         prompt: bytes string to process
-        class_prompt: Channel class' prompt pattern
+        class_prompt: Channel class prompt pattern; never re.escape class prompt pattern
 
     Returns:
         output: bytes string each line right stripped
@@ -70,7 +73,10 @@ def get_prompt_pattern(prompt: str, class_prompt: str) -> Pattern[bytes]:
         bytes_check_prompt = check_prompt.encode()
     else:
         bytes_check_prompt = check_prompt
+
     if bytes_check_prompt.startswith(b"^") and bytes_check_prompt.endswith(b"$"):
+        return re.compile(bytes_check_prompt, flags=re.M | re.I)
+    if check_prompt == class_prompt:
         return re.compile(bytes_check_prompt, flags=re.M | re.I)
     return re.compile(re.escape(bytes_check_prompt))
 

--- a/scrapli/helper.py
+++ b/scrapli/helper.py
@@ -36,7 +36,7 @@ def _find_transport_plugin(transport: str) -> Tuple[Any, Tuple[str, ...]]:
         err = f"Module '{exc.name}' not found!"
         msg = f"***** {err} {'*' * (80 - len(err))}"
         fix = (
-            f"To resolve this issue, ensure you are referencing a valid transport plugin. Transport"
+            "To resolve this issue, ensure you are referencing a valid transport plugin. Transport"
             " plugins should be named similar to `scrapli_paramiko` or `scrapli_ssh2`, and can be "
             "selected by passing simply `paramiko` or `ssh2` into the scrapli driver."
         )

--- a/scrapli/helper.py
+++ b/scrapli/helper.py
@@ -273,7 +273,7 @@ def resolve_ssh_config(ssh_config_file: str) -> str:
         ssh_config_file: string representation of ssh config file to try to use
 
     Returns:
-        str: string to path fro ssh config file or an empty string
+        str: string path to ssh config file or an empty string
 
     Raises:
         N/A
@@ -299,7 +299,7 @@ def resolve_ssh_known_hosts(ssh_known_hosts: str) -> str:
         ssh_known_hosts: string representation of ssh config file to try to use
 
     Returns:
-        str: string to path fro ssh config file or an empty string
+        str: string path to ssh known hosts file or an empty string
 
     Raises:
         N/A
@@ -312,3 +312,24 @@ def resolve_ssh_known_hosts(ssh_known_hosts: str) -> str:
     if Path("/etc/ssh/ssh_known_hosts").is_file():
         return str(Path("/etc/ssh/ssh_known_hosts"))
     return ""
+
+
+def resolve_file(file: str) -> str:
+    """
+    Resolve file from provided string
+
+    Args:
+        file: string path to file
+
+    Returns:
+        str: string path to file
+
+    Raises:
+        ValueError: if file cannot be resolved
+
+    """
+    if Path(file).is_file():
+        return str(Path(file))
+    if Path(os.path.expanduser(file)).is_file():
+        return str(Path(os.path.expanduser(file)))
+    raise ValueError(f"File path `{file}` could not be resolved")

--- a/scrapli/ssh_config.py
+++ b/scrapli/ssh_config.py
@@ -2,7 +2,13 @@
 import os
 import re
 import shlex
-from typing import Dict, Match, Optional
+import sys
+from typing import Dict, Optional
+
+if sys.version_info >= (3, 8):
+    Match = re.Match
+else:
+    from typing import Match
 
 
 class SSHConfig:

--- a/scrapli/transport/systemssh.py
+++ b/scrapli/transport/systemssh.py
@@ -559,6 +559,7 @@ class SystemSSHTransport(Transport):
                 return True
         return False
 
+    @operation_timeout("timeout_transport", "Timed out reading from transport")
     def read(self) -> bytes:
         """
         Read data from the channel
@@ -580,6 +581,7 @@ class SystemSSHTransport(Transport):
             return self.session.read(read_bytes)
         return b""
 
+    @operation_timeout("timeout_transport", "Timed out writing to transport")
     def write(self, channel_input: str) -> None:
         """
         Write data to the channel

--- a/scrapli/transport/telnet.py
+++ b/scrapli/transport/telnet.py
@@ -234,7 +234,7 @@ class TelnetTransport(Transport):
                 fd_ready, _, _ = select([telnet_session_fd], [], [], 0)
                 if telnet_session_fd in fd_ready:
                     break
-                LOG.debug(f"PTY fd not ready yet...")
+                LOG.debug("PTY fd not ready yet...")
             output = b""
             while True:
                 output += telnet_session.read_eager()

--- a/scrapli/transport/telnet.py
+++ b/scrapli/transport/telnet.py
@@ -291,6 +291,7 @@ class TelnetTransport(Transport):
             return True
         return False
 
+    @operation_timeout("timeout_transport", "Timed out reading from transport")
     def read(self) -> bytes:
         """
         Read data from the channel
@@ -307,6 +308,7 @@ class TelnetTransport(Transport):
         """
         return self.session.read_eager()
 
+    @operation_timeout("timeout_transport", "Timed out writing to transport")
     def write(self, channel_input: str) -> None:
         """
         Write data to the channel

--- a/scrapli/transport/telnet.py
+++ b/scrapli/transport/telnet.py
@@ -1,6 +1,5 @@
 """scrapli.transport.telnet"""
 import re
-import time
 from logging import getLogger
 from select import select
 from telnetlib import Telnet
@@ -228,25 +227,30 @@ class TelnetTransport(Transport):
             telnet_session_fd = telnet_session.fileno()
             self.session_lock.acquire()
             telnet_session.write(self._comms_return_char.encode())
-            time.sleep(0.25)
-            fd_ready, _, _ = select([telnet_session_fd], [], [], 0)
-            if telnet_session_fd in fd_ready:
-                output = b""
-                while True:
-                    output += telnet_session.read_eager()
-                    # we do not need to deal w/ line replacement for the actual output, only for
-                    # parsing if a prompt-like thing is at the end of the output
-                    output = output.replace(b"\r", b"")
-                    if self._comms_ansi:
-                        output = strip_ansi(output=output)
-                    channel_match = re.search(pattern=prompt_pattern, string=output)
-                    if channel_match:
-                        self.session_lock.release()
-                        self._isauthenticated = True
-                        return True
-                    if b"password" in output.lower():
-                        # if we see "password" auth failed... hopefully true in all scenarios!
-                        return False
+            while True:
+                # almost all of the time we don't need a while loop here, but every once in a while
+                # fd won't be ready which causes a failure without an obvious root cause,
+                # loop/logging to hopefully help with that
+                fd_ready, _, _ = select([telnet_session_fd], [], [], 0)
+                if telnet_session_fd in fd_ready:
+                    break
+                LOG.debug(f"PTY fd not ready yet...")
+            output = b""
+            while True:
+                output += telnet_session.read_eager()
+                # we do not need to deal w/ line replacement for the actual output, only for
+                # parsing if a prompt-like thing is at the end of the output
+                output = output.replace(b"\r", b"")
+                if self._comms_ansi:
+                    output = strip_ansi(output=output)
+                channel_match = re.search(pattern=prompt_pattern, string=output)
+                if channel_match:
+                    self.session_lock.release()
+                    self._isauthenticated = True
+                    return True
+                if b"password" in output.lower():
+                    # if we see "password" auth failed... hopefully true in all scenarios!
+                    return False
         self.session_lock.release()
         return False
 

--- a/scrapli/transport/transport.py
+++ b/scrapli/transport/transport.py
@@ -1,4 +1,5 @@
 """scrapli.transport.transport"""
+import atexit
 import time
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
@@ -256,6 +257,14 @@ class Transport(ABC):
                 the keepalive_interval
 
         """
+
+        def kill_transport() -> None:
+            if self.isalive():
+                self.close()
+
+        # ensure the transport is closed so keepalive can terminate if main thread tries to exit
+        atexit.register(kill_transport)
+
         lock_counter = 0
         last_keepalive = datetime.now()
         while True:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -65,8 +65,8 @@ def conn(device_type, transport):
 
     timeout_transport = 5
     timeout_ops = 5
-    if device_type == "juniper_junos":
-        # commits on vsrx take one whole eternity...
+    if device_type == "juniper_junos" or device_type == "cisco_iosxr":
+        # commits on vsrx take one whole eternity... and iosxr container is just flakey
         timeout_transport = 30
         timeout_ops = 30
 

--- a/tests/functional/test_data/source/arista_eos/send_commands
+++ b/tests/functional/test_data/source/arista_eos/send_commands
@@ -1,0 +1,2 @@
+show run | i ZTP
+show run | i ZTP

--- a/tests/functional/test_data/source/arista_eos/send_configs
+++ b/tests/functional/test_data/source/arista_eos/send_configs
@@ -1,0 +1,2 @@
+interface loopback123
+description scrapli was here

--- a/tests/functional/test_data/source/cisco_iosxe/send_commands
+++ b/tests/functional/test_data/source/cisco_iosxe/send_commands
@@ -1,0 +1,2 @@
+show run | i hostname
+show run | i hostname

--- a/tests/functional/test_data/source/cisco_iosxe/send_configs
+++ b/tests/functional/test_data/source/cisco_iosxe/send_configs
@@ -1,0 +1,2 @@
+interface loopback123
+description scrapli was here

--- a/tests/functional/test_data/source/cisco_iosxr/send_commands
+++ b/tests/functional/test_data/source/cisco_iosxr/send_commands
@@ -1,0 +1,2 @@
+show run | i MgmtEth0
+show run | i MgmtEth0

--- a/tests/functional/test_data/source/cisco_iosxr/send_configs
+++ b/tests/functional/test_data/source/cisco_iosxr/send_configs
@@ -1,0 +1,3 @@
+interface loopback123
+description scrapli was here
+commit

--- a/tests/functional/test_data/source/cisco_nxos/send_commands
+++ b/tests/functional/test_data/source/cisco_nxos/send_commands
@@ -1,0 +1,2 @@
+show run | i scp-server
+show run | i scp-server

--- a/tests/functional/test_data/source/cisco_nxos/send_configs
+++ b/tests/functional/test_data/source/cisco_nxos/send_configs
@@ -1,0 +1,2 @@
+interface loopback123
+description scrapli was here

--- a/tests/functional/test_data/source/juniper_junos/send_commands
+++ b/tests/functional/test_data/source/juniper_junos/send_commands
@@ -1,0 +1,2 @@
+show configuration | match 10.0.0.15
+show configuration | match 10.0.0.15

--- a/tests/functional/test_data/source/juniper_junos/send_configs
+++ b/tests/functional/test_data/source/juniper_junos/send_configs
@@ -1,0 +1,2 @@
+set interfaces fxp0 unit 0 description "scrapli was here"
+commit

--- a/tests/functional/test_data/test_cases.py
+++ b/tests/functional/test_data/test_cases.py
@@ -34,6 +34,12 @@ TEST_CASES = {
                 f"{TEST_DATA_PATH}/expected/cisco_iosxe/send_command_long_strip"
             ).read(),
         },
+        "send_commands_from_file": {
+            "file": f"{TEST_DATA_PATH}/source/cisco_iosxe/send_commands",
+            "expected_no_strip": ["hostname csr1000v\ncsr1000v#", "hostname csr1000v\ncsr1000v#"],
+            "expected_strip": ["hostname csr1000v", "hostname csr1000v"],
+        },
+        "send_commands_error": {"commands": ["show version", "show tacocat", "show version"],},
         "send_interactive_normal_response": {
             "command": [("clear logg", "Clear logging buffer [confirm]"), ("", "csr1000v#")],
             "expected": "clear logg\nClear logging buffer [confirm]\n\ncsr1000v#",
@@ -50,6 +56,16 @@ TEST_CASES = {
             "verification_expected_strip": "Building configuration...\n\nCurrent configuration : CONFIG_BYTES"
             "\n!\ninterface Loopback123\n description scrapli was here\n no ip "
             "address\nend",
+            "teardown_configs": "no interface loopback123",
+        },
+        "send_configs_from_file": {
+            "file": f"{TEST_DATA_PATH}/source/cisco_iosxe/send_configs",
+            "expected_no_strip": ["csr1000v(config-if)#", "csr1000v(config-if)#"],
+            "expected_strip": ["", ""],
+            "teardown_configs": "no interface loopback123",
+        },
+        "send_configs_error": {
+            "configs": ["interface loopback123", "show tacocat", "description tacocat was here"],
             "teardown_configs": "no interface loopback123",
         },
         "sanitize_response": cisco_iosxe_clean_response,
@@ -74,6 +90,12 @@ TEST_CASES = {
                 f"{TEST_DATA_PATH}/expected/cisco_nxos/send_command_long_strip"
             ).read(),
         },
+        "send_commands_from_file": {
+            "file": f"{TEST_DATA_PATH}/source/cisco_nxos/send_commands",
+            "expected_no_strip": ["feature scp-server\nswitch#", "feature scp-server\nswitch#"],
+            "expected_strip": ["feature scp-server", "feature scp-server"],
+        },
+        "send_commands_error": {"commands": ["show version", "show tacocat", "show version"],},
         "send_interactive_normal_response": {
             "command": [
                 ("delete bootflash:virtual-instance.conf", "(yes/no/abort)   [y]"),
@@ -95,6 +117,16 @@ TEST_CASES = {
             "configuration last done at: TIME_STAMP_REPLACED\n!Time: "
             "TIME_STAMP_REPLACED\n\nversion 9.2(4) Bios:version\n\ninterface "
             "loopback123\n  description scrapli was here",
+            "teardown_configs": "no interface loopback123",
+        },
+        "send_configs_from_file": {
+            "file": f"{TEST_DATA_PATH}/source/cisco_nxos/send_configs",
+            "expected_no_strip": ["switch(config-if)#", "switch(config-if)#"],
+            "expected_strip": ["", ""],
+            "teardown_configs": "no interface loopback123",
+        },
+        "send_configs_error": {
+            "configs": ["interface loopback123", "show tacocat", "description tacocat was here"],
             "teardown_configs": "no interface loopback123",
         },
         "sanitize_response": cisco_nxos_clean_response,
@@ -119,6 +151,18 @@ TEST_CASES = {
                 f"{TEST_DATA_PATH}/expected/cisco_iosxr/send_command_long_strip"
             ).read(),
         },
+        "send_commands_from_file": {
+            "file": f"{TEST_DATA_PATH}/source/cisco_iosxr/send_commands",
+            "expected_no_strip": [
+                "TIME_STAMP_REPLACED\nBuilding configuration...\ninterface MgmtEth0/RP0/CPU0/0\nRP/0/RP0/CPU0:ios#",
+                "TIME_STAMP_REPLACED\nBuilding configuration...\ninterface MgmtEth0/RP0/CPU0/0\nRP/0/RP0/CPU0:ios#",
+            ],
+            "expected_strip": [
+                "TIME_STAMP_REPLACED\nBuilding configuration...\ninterface MgmtEth0/RP0/CPU0/0",
+                "TIME_STAMP_REPLACED\nBuilding configuration...\ninterface MgmtEth0/RP0/CPU0/0",
+            ],
+        },
+        "send_commands_error": {"commands": ["show version", "show tacocat", "show version"],},
         "send_interactive_normal_response": None,
         "send_interactive_hidden_response": None,
         "send_configs": {
@@ -130,6 +174,13 @@ TEST_CASES = {
             "verification_expected_strip": "TIME_STAMP_REPLACED\ninterface Loopback123\n description scrapli was here\n!",
             "teardown_configs": ["no interface loopback123", "commit"],
         },
+        "send_configs_from_file": {
+            "file": f"{TEST_DATA_PATH}/source/cisco_iosxr/send_configs",
+            "expected_no_strip": ["RP/0/RP0/CPU0:ios(config-if)#", "RP/0/RP0/CPU0:ios(config-if)#"],
+            "expected_strip": ["", ""],
+            "teardown_configs": ["no interface loopback123", "commit"],
+        },
+        "send_configs_error": None,
         "sanitize_response": cisco_iosxr_clean_response,
     },
     "arista_eos": {
@@ -152,6 +203,18 @@ TEST_CASES = {
                 f"{TEST_DATA_PATH}/expected/arista_eos/send_command_long_strip"
             ).read(),
         },
+        "send_commands_from_file": {
+            "file": f"{TEST_DATA_PATH}/source/arista_eos/send_commands",
+            "expected_no_strip": [
+                "logging level ZTP informational\nlocalhost#",
+                "logging level ZTP informational\nlocalhost#",
+            ],
+            "expected_strip": [
+                "logging level ZTP informational",
+                "logging level ZTP informational",
+            ],
+        },
+        "send_commands_error": {"commands": ["show version", "show tacocat", "show version"],},
         "send_interactive_normal_response": None,
         "send_interactive_hidden_response": None,
         "send_configs": {
@@ -161,6 +224,16 @@ TEST_CASES = {
             "verification": "show run int loopback123",
             "verification_expected_no_strip": "interface Loopback123\n   description scrapli was here\nlocalhost#",
             "verification_expected_strip": "interface Loopback123\n   description scrapli was here",
+            "teardown_configs": "no interface loopback123",
+        },
+        "send_configs_from_file": {
+            "file": f"{TEST_DATA_PATH}/source/arista_eos/send_configs",
+            "expected_no_strip": ["localhost(config-if-Lo123)#", "localhost(config-if-Lo123)#"],
+            "expected_strip": ["", ""],
+            "teardown_configs": "no interface loopback123",
+        },
+        "send_configs_error": {
+            "configs": ["interface loopback123", "show tacocat", "description tacocat was here"],
             "teardown_configs": "no interface loopback123",
         },
         "sanitize_response": arista_eos_clean_response,
@@ -181,6 +254,18 @@ TEST_CASES = {
                 f"{TEST_DATA_PATH}/expected/juniper_junos/send_command_long_strip"
             ).read(),
         },
+        "send_commands_from_file": {
+            "file": f"{TEST_DATA_PATH}/source/juniper_junos/send_commands",
+            "expected_no_strip": [
+                "                address 10.0.0.15/24;\n\nvrnetlab>",
+                "                address 10.0.0.15/24;\n\nvrnetlab>",
+            ],
+            "expected_strip": [
+                "                address 10.0.0.15/24;",
+                "                address 10.0.0.15/24;",
+            ],
+        },
+        "send_commands_error": {"commands": ["show version", "show tacocat", "show version"],},
         "send_interactive_normal_response": None,
         "send_interactive_hidden_response": None,
         "send_configs": {
@@ -192,6 +277,13 @@ TEST_CASES = {
             "verification_expected_strip": 'unit 0 {\n    description "scrapli was here";\n    family inet {\n        address 10.0.0.15/24;\n    }\n}',
             "teardown_configs": ["delete interfaces fxp0 unit 0 description", "commit"],
         },
+        "send_configs_from_file": {
+            "file": f"{TEST_DATA_PATH}/source/juniper_junos/send_configs",
+            "expected_no_strip": ["[edit]\nvrnetlab#", "commit complete\n\n[edit]\nvrnetlab#"],
+            "expected_strip": ["[edit]", "commit complete\n\n[edit]"],
+            "teardown_configs": ["delete interfaces fxp0 unit 0 description", "commit"],
+        },
+        "send_configs_error": None,
         "sanitize_response": juniper_junos_clean_response,
     },
     "linux": {

--- a/tests/functional/test_data/test_cases.py
+++ b/tests/functional/test_data/test_cases.py
@@ -180,7 +180,10 @@ TEST_CASES = {
             "expected_strip": ["", ""],
             "teardown_configs": ["no interface loopback123", "commit"],
         },
-        "send_configs_error": None,
+        "send_configs_error": {
+            "configs": ["interface loopback123", "show tacocat", "description tacocat was here"],
+            "teardown_configs": "",
+        },
         "sanitize_response": cisco_iosxr_clean_response,
     },
     "arista_eos": {
@@ -283,7 +286,14 @@ TEST_CASES = {
             "expected_strip": ["[edit]", "commit complete\n\n[edit]"],
             "teardown_configs": ["delete interfaces fxp0 unit 0 description", "commit"],
         },
-        "send_configs_error": None,
+        "send_configs_error": {
+            "configs": [
+                "set interfaces fxp0 description tacocat",
+                "show tacocat",
+                "set interfaces fxp0 description tacocat",
+            ],
+            "teardown_configs": "delete interfaces fxp0 description",
+        },
         "sanitize_response": juniper_junos_clean_response,
     },
     "linux": {

--- a/tests/functional/test_drivers.py
+++ b/tests/functional/test_drivers.py
@@ -142,6 +142,25 @@ class TestNetworkDevice:
         for expected_response, response in zip(expected_responses, responses):
             assert sanitize_response(response.result) == expected_response
 
+    @pytest.mark.parametrize(
+        "strip_prompt", [True, False], ids=["strip_prompt", "no_strip_prompt"],
+    )
+    def test_send_commands_from_file(self, conn, device_type, transport, strip_prompt):
+        file = TEST_CASES[device_type]["send_commands_from_file"]["file"]
+        expected_type = "expected_no_strip" if not strip_prompt else "expected_strip"
+        expected_responses = TEST_CASES[device_type]["send_commands_from_file"][expected_type]
+        sanitize_response = TEST_CASES[device_type]["sanitize_response"]
+        responses = conn.send_commands_from_file(file=file, strip_prompt=strip_prompt)
+        for expected_response, response in zip(expected_responses, responses):
+            assert sanitize_response(response.result) == expected_response
+
+    def test_send_commands_stop_on_failed(self, conn, device_type, transport):
+        commands = TEST_CASES[device_type]["send_commands_error"]["commands"]
+        responses = conn.send_commands(commands=commands, stop_on_failed=True)
+        assert len(responses) == 2
+        assert responses[0].failed is False
+        assert responses[1].failed is True
+
     def test_send_interactive_normal_response(self, conn, device_type, transport):
         if TEST_CASES[device_type]["send_interactive_normal_response"] is None:
             pytest.skip(
@@ -182,12 +201,45 @@ class TestNetworkDevice:
         assert sanitize_response(verification_response.result) == expected_verification
         conn.send_configs(configs=teardown_configs)
 
+    @pytest.mark.parametrize(
+        "strip_prompt", [True, False], ids=["strip_prompt", "no_strip_prompt"],
+    )
+    def test_send_configs_from_file(self, conn, device_type, transport, strip_prompt):
+        file = TEST_CASES[device_type]["send_configs_from_file"]["file"]
+        expected_type = "expected_no_strip" if not strip_prompt else "expected_strip"
+        expected_responses = TEST_CASES[device_type]["send_configs"][expected_type]
+        verification = TEST_CASES[device_type]["send_configs"]["verification"]
+        expected_verification = TEST_CASES[device_type]["send_configs"][
+            f"verification_{expected_type}"
+        ]
+        teardown_configs = TEST_CASES[device_type]["send_configs"]["teardown_configs"]
+        sanitize_response = TEST_CASES[device_type]["sanitize_response"]
+        responses = conn.send_configs_from_file(file=file, strip_prompt=strip_prompt)
+        for expected_response, response in zip(expected_responses, responses):
+            assert response.result == expected_response
+        verification_response = conn.send_command(command=verification, strip_prompt=strip_prompt)
+        assert sanitize_response(verification_response.result) == expected_verification
+        conn.send_configs(configs=teardown_configs)
+
+    def test_send_configs_stop_on_failed(self, conn, device_type, transport):
+        if TEST_CASES[device_type]["send_configs_error"] is None:
+            pytest.skip(
+                f"test_send_configs_stop_on_failed for device type {device_type} not tested yet, need to overhaul privilege levels..."
+            )
+        configs = TEST_CASES[device_type]["send_configs_error"]["configs"]
+        teardown_configs = TEST_CASES[device_type]["send_configs_error"]["teardown_configs"]
+        responses = conn.send_configs(configs=configs, stop_on_failed=True)
+        assert len(responses) == 2
+        assert responses[0].failed is False
+        assert responses[1].failed is True
+        conn.send_configs(configs=teardown_configs)
+
     def test_isalive_and_close(self, conn, device_type, transport):
         assert conn.isalive() is True
         conn.close()
         # unsure why but w/out a tiny sleep pytest just plows ahead and the connection doesnt
         # close in time for the next assert
-        time.sleep(0.1)
+        time.sleep(0.5)
         assert conn.isalive() is False
 
 
@@ -215,7 +267,7 @@ def test_context_manager(device_type, transport):
         assert conn.isalive() is True
     # unsure why but w/out a tiny sleep pytest just plows ahead and the connection doesnt
     # close in time for the next assert
-    time.sleep(0.1)
+    time.sleep(0.5)
     assert conn.isalive() is False
 
 
@@ -237,7 +289,7 @@ def test_public_key_auth(device_type, transport):
         assert conn.isalive() is True
     # unsure why but w/out a tiny sleep pytest just plows ahead and the connection doesnt
     # close in time for the next assert
-    time.sleep(0.1)
+    time.sleep(0.2)
     assert conn.isalive() is False
 
 

--- a/tests/functional/test_drivers.py
+++ b/tests/functional/test_drivers.py
@@ -312,6 +312,6 @@ def test_public_key_auth_failure(device_type, transport):
     with pytest.raises(ScrapliAuthenticationFailed) as exc:
         conn.open()
     assert str(exc.value) == (
-        f"Public key authentication to host {device['host']} failed. Missing username or "
-        "password unable to attempt password authentication."
+        f"Failed to authenticate to host 172.18.0.11 with private key `{INVALID_PRIVATE_KEY}`. "
+        "Unable to continue authentication, missing username, password, or both."
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,10 +10,10 @@ from scrapli.transport.transport import Transport
 
 
 class MockScrape(Scrape):
-    def __init__(self, channel_ops, initial_bytes, *args, **kwargs):
+    def __init__(self, channel_ops, initial_bytes, **kwargs):
         self.channel_ops = channel_ops
         self.initial_bytes = initial_bytes
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def _transport_factory(self, transport: str) -> Tuple[Callable[..., Any], Dict[str, Any]]:
         """
@@ -89,10 +89,13 @@ class MockTransport(Transport):
 
 
 class MockNetworkDriver(MockScrape, NetworkDriver):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.privs = PRIVS
-        self.auth_secondary = "password"
+    def __init__(self, **kwargs):
+        super().__init__(
+            privilege_levels=PRIVS,
+            default_desired_privilege_level="privilege_exec",
+            auth_secondary="password",
+            **kwargs,
+        )
 
     def open(self):
         # Overriding "normal" network driver open method as we don't need to worry about disable
@@ -100,6 +103,7 @@ class MockNetworkDriver(MockScrape, NetworkDriver):
         self.transport = self.transport_class(**self.transport_args)
         self.transport.open()
         self.channel = Channel(self.transport, **self.channel_args)
+        self._current_priv_level = self.privilege_levels[self.default_desired_privilege_level]
 
 
 class MockGenericDriver(MockScrape, GenericDriver):

--- a/tests/unit/driver/test_driver.py
+++ b/tests/unit/driver/test_driver.py
@@ -24,7 +24,7 @@ def test__repr():
         "timeout_exit=True, keepalive=False, keepalive_interval=30, keepalive_type='network', "
         "keepalive_pattern='\\x05', comms_prompt_pattern='^[a-z0-9.\\\\-@()/:]{1,48}[#>$]\\\\s*$', "
         "comms_return_char='\\n', comms_ansi=False, ssh_config_file='', ssh_known_hosts_file='', on_open=None, "
-        "on_close=None, transport='system')"
+        "on_close=None, transport='system', transport_options=None)"
     )
 
 

--- a/tests/unit/driver/test_driver.py
+++ b/tests/unit/driver/test_driver.py
@@ -19,7 +19,7 @@ def test__repr():
     conn = Scrape(host="myhost")
     assert (
         repr(conn)
-        == "Scrape(host='myhost', port=22, auth_username='', auth_password='', auth_private_key=b'', "
+        == "Scrape(host='myhost', port=22, auth_username='', auth_password='', auth_private_key='', "
         "auth_strict_key=True, auth_bypass=False, timeout_socket=5, timeout_transport=10, timeout_ops=30, "
         "timeout_exit=True, keepalive=False, keepalive_interval=30, keepalive_type='network', "
         "keepalive_pattern='\\x05', comms_prompt_pattern='^[a-z0-9.\\\\-@()/:]{1,48}[#>$]\\\\s*$', "
@@ -116,7 +116,7 @@ def test_exceptions_raised(attr_setup):
         ("auth_username", "tacocat ", "tacocat"),
         ("auth_password", "tacocat", "tacocat"),
         ("auth_password", "tacocat ", "tacocat"),
-        ("auth_private_key", f"{UNIT_TEST_DIR}_ssh_config", f"{UNIT_TEST_DIR}_ssh_config".encode()),
+        ("auth_private_key", f"{UNIT_TEST_DIR}_ssh_config", f"{UNIT_TEST_DIR}_ssh_config"),
         ("auth_strict_key", False, False),
         ("timeout_socket", 100, 100),
         ("timeout_transport", 100, 100),
@@ -177,7 +177,7 @@ def test_valid_private_key_file():
     auth_private_key = f"{UNIT_TEST_DIR}_ssh_private_key"
     conn = Scrape(host="myhost", auth_private_key=auth_private_key)
     assert (
-        conn._initialization_args["auth_private_key"] == f"{UNIT_TEST_DIR}_ssh_private_key".encode()
+        conn._initialization_args["auth_private_key"] == f"{UNIT_TEST_DIR}_ssh_private_key"
     )
 
 

--- a/tests/unit/driver/test_driver.py
+++ b/tests/unit/driver/test_driver.py
@@ -176,9 +176,7 @@ def test_attr_assignment(attr_setup):
 def test_valid_private_key_file():
     auth_private_key = f"{UNIT_TEST_DIR}_ssh_private_key"
     conn = Scrape(host="myhost", auth_private_key=auth_private_key)
-    assert (
-        conn._initialization_args["auth_private_key"] == f"{UNIT_TEST_DIR}_ssh_private_key"
-    )
+    assert conn._initialization_args["auth_private_key"] == f"{UNIT_TEST_DIR}_ssh_private_key"
 
 
 @pytest.mark.skipif(

--- a/tests/unit/driver/test_generic_driver.py
+++ b/tests/unit/driver/test_generic_driver.py
@@ -1,4 +1,8 @@
+from pathlib import Path
+
 import pytest
+
+import scrapli
 
 try:
     import ntc_templates
@@ -7,6 +11,9 @@ try:
     textfsm_avail = True
 except ImportError:
     textfsm_avail = False
+
+
+TEST_DATA_PATH = f"{Path(scrapli.__file__).parents[1]}/tests/unit/test_data"
 
 
 @pytest.mark.parametrize(
@@ -104,6 +111,53 @@ def test_send_commands(mocked_generic_driver):
     ]
     conn = mocked_generic_driver(test_operations)
     outputs = conn.send_commands([channel_input_1, channel_input_2], strip_prompt=False)
+    assert outputs[0].result == channel_output_1
+    assert outputs[1].result == channel_output_2
+
+
+def test_send_commands_from_file(mocked_generic_driver):
+    channel_input_1 = "show ip access-lists"
+    channel_output_1 = """Extended IP access list ext_acl_fw
+        10 deny ip 0.0.0.0 0.255.255.255 any
+        20 deny ip 10.0.0.0 0.255.255.255 any
+        30 deny ip 100.64.0.0 0.63.255.255 any (2 matches)
+        40 deny ip 127.0.0.0 0.255.255.255 any
+        50 deny ip 169.254.0.0 0.0.255.255 any
+        60 deny ip 172.16.0.0 0.15.255.255 any
+        70 deny ip 192.0.0.0 0.0.0.255 any
+        80 deny ip 192.0.2.0 0.0.0.255 any
+        90 deny ip 192.168.0.0 0.0.255.255 any
+        100 deny ip 198.18.0.0 0.1.255.255 any
+        110 deny ip 198.51.100.0 0.0.0.255 any
+        120 deny ip 203.0.113.0 0.0.0.255 any
+        130 deny ip 224.0.0.0 15.255.255.255 any
+        140 deny ip 240.0.0.0 15.255.255.255 any
+3560CX#"""
+    channel_input_2 = "show ip access-lists"
+    channel_output_2 = """Extended IP access list ext_acl_fw
+            10 deny ip 0.0.0.0 0.255.255.255 any
+            20 deny ip 10.0.0.0 0.255.255.255 any
+            30 deny ip 100.64.0.0 0.63.255.255 any (2 matches)
+            40 deny ip 127.0.0.0 0.255.255.255 any
+            50 deny ip 169.254.0.0 0.0.255.255 any
+            60 deny ip 172.16.0.0 0.15.255.255 any
+            70 deny ip 192.0.0.0 0.0.0.255 any
+            80 deny ip 192.0.2.0 0.0.0.255 any
+            90 deny ip 192.168.0.0 0.0.255.255 any
+            100 deny ip 198.18.0.0 0.1.255.255 any
+            110 deny ip 198.51.100.0 0.0.0.255 any
+            120 deny ip 203.0.113.0 0.0.0.255 any
+            130 deny ip 224.0.0.0 15.255.255.255 any
+            140 deny ip 240.0.0.0 15.255.255.255 any
+3560CX#"""
+    test_operations = [
+        (channel_input_1, channel_output_1),
+        (channel_input_2, channel_output_2),
+    ]
+    conn = mocked_generic_driver(test_operations)
+    outputs = conn.send_commands_from_file(
+        file=f"{TEST_DATA_PATH}/send_commands", strip_prompt=False
+    )
     assert outputs[0].result == channel_output_1
     assert outputs[1].result == channel_output_2
 

--- a/tests/unit/driver/test_network_driver.py
+++ b/tests/unit/driver/test_network_driver.py
@@ -1,8 +1,10 @@
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
+import scrapli
 from scrapli.driver.network_driver import PrivilegeLevel
 from scrapli.exceptions import CouldNotAcquirePrivLevel, UnknownPrivLevel
 from scrapli.response import Response
@@ -14,6 +16,8 @@ try:
     textfsm_avail = True
 except ImportError:
     textfsm_avail = False
+
+TEST_DATA_PATH = f"{Path(scrapli.__file__).parents[1]}/tests/unit/test_data"
 
 
 @pytest.mark.parametrize(
@@ -433,9 +437,9 @@ def test_send_configs(mocked_network_driver):
     channel_input_7 = "\n"
     channel_output_7 = "XC0653(config)#"
     channel_input_8 = "end"
-    channel_output_8 = "3560CX#"
+    channel_output_8 = "XC0653#"
     channel_input_9 = "\n"
-    channel_output_9 = "\n3560CX#"
+    channel_output_9 = "\nXC0653#"
     test_operations = [
         (channel_input_1, channel_output_1),
         (channel_input_2, channel_output_2),
@@ -450,6 +454,43 @@ def test_send_configs(mocked_network_driver):
     conn = mocked_network_driver(test_operations)
     conn.default_desired_priv = "privilege_exec"
     output = conn.send_configs(channel_input_5, strip_prompt=False)
+    assert output[0].result == channel_output_5
+
+
+def test_send_configs_from_file(mocked_network_driver):
+    channel_input_1 = "\n"
+    channel_output_1 = "\n3560CX#"
+    channel_input_2 = "\n"
+    channel_output_2 = "\n3560CX#"
+    channel_input_3 = "configure terminal"
+    channel_output_3 = """Enter configuration commands, one per line.  End with CNTL/Z.
+3560CX(config)#"""
+    channel_input_4 = "\n"
+    channel_output_4 = "3560CX(config)#"
+    channel_input_5 = "hostname XC0653"
+    channel_output_5 = "XC0653(config)#"
+    channel_input_6 = "\n"
+    channel_output_6 = "XC0653(config)#"
+    channel_input_7 = "\n"
+    channel_output_7 = "XC0653(config)#"
+    channel_input_8 = "end"
+    channel_output_8 = "XC0653#"
+    channel_input_9 = "\n"
+    channel_output_9 = "\nXC0653#"
+    test_operations = [
+        (channel_input_1, channel_output_1),
+        (channel_input_2, channel_output_2),
+        (channel_input_3, channel_output_3),
+        (channel_input_4, channel_output_4),
+        (channel_input_5, channel_output_5),
+        (channel_input_6, channel_output_6),
+        (channel_input_7, channel_output_7),
+        (channel_input_8, channel_output_8),
+        (channel_input_9, channel_output_9),
+    ]
+    conn = mocked_network_driver(test_operations)
+    conn.default_desired_priv = "privilege_exec"
+    output = conn.send_configs_from_file(file=f"{TEST_DATA_PATH}/send_configs", strip_prompt=False)
     assert output[0].result == channel_output_5
 
 

--- a/tests/unit/test_data/send_commands
+++ b/tests/unit/test_data/send_commands
@@ -1,0 +1,2 @@
+show ip access-lists
+show ip access-lists

--- a/tests/unit/test_data/send_configs
+++ b/tests/unit/test_data/send_configs
@@ -1,0 +1,1 @@
+hostname XC0653

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -32,7 +32,7 @@ def test_get_prompt_pattern_class_pattern():
 
 def test_get_prompt_pattern_class_pattern_no_line_start_end_markers():
     class_pattern = "averygoodpattern"
-    result = get_prompt_pattern("", class_pattern)
+    result = get_prompt_pattern(class_pattern, "")
     assert result == re.compile(b"averygoodpattern")
 
 

--- a/tests/unit/transport/test_systemssh.py
+++ b/tests/unit/transport/test_systemssh.py
@@ -11,3 +11,64 @@ def test_creation():
     assert conn.host == "localhost"
     assert conn.port == 22
     assert conn._isauthenticated is False
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="systemssh not supported on windows")
+def test_build_open_cmd():
+    conn = SystemSSHTransport("localhost")
+    assert conn.open_cmd == [
+        "ssh",
+        "localhost",
+        "-p",
+        "22",
+        "-o",
+        "ConnectTimeout=5",
+        "-o",
+        "ServerAliveInterval=5",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-F",
+        "/dev/null",
+    ]
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="systemssh not supported on windows")
+@pytest.mark.parametrize(
+    "eof_msg",
+    [
+        (b"Host key verification failed", "Host key verification failed for host localhost",),
+        (b"Operation timed out", "Timed out connecting to host localhost",),
+        (b"Connection timed out", "Timed out connecting to host localhost",),
+        (b"No route to host", "No route to host localhost",),
+        (b"no matching cipher found", "No matching cipher found for host localhost",),
+        (
+            b"no matching cipher found, their offer: aes128-cbc,aes256-cbc",
+            "No matching cipher found for host localhost, their offer: aes128-cbc,aes256-cbc",
+        ),
+    ],
+    ids=[
+        "host key verification",
+        "operation time out",
+        "connection time out",
+        "no route to host",
+        "no matching cipher",
+        "no matching cipher found ciphers",
+    ],
+)
+def test_pty_authentication_error_messages(eof_msg):
+    conn = SystemSSHTransport("localhost")
+    error_msg = eof_msg[0]
+    expected_msg = eof_msg[1]
+    actual_msg = conn._pty_authentication_eof_handler(error_msg)
+    assert actual_msg == expected_msg
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="systemssh not supported on windows")
+def test_set_timeout():
+    conn = SystemSSHTransport("localhost")
+    assert conn.timeout_transport == 5
+    conn.set_timeout(1000)
+    assert conn.timeout_transport == 1000
+    conn.timeout_transport = 9999
+    conn.set_timeout()
+    assert conn.timeout_transport == 9999

--- a/tests/unit/transport/test_systemssh.py
+++ b/tests/unit/transport/test_systemssh.py
@@ -33,6 +33,28 @@ def test_build_open_cmd():
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="systemssh not supported on windows")
+def test_build_open_cmd_user_options():
+    conn = SystemSSHTransport(
+        "localhost", transport_options={"open_cmd": ["oKexAlgorithms=+diffie-hellman-group1-sha1"]}
+    )
+    assert conn.open_cmd == [
+        "ssh",
+        "localhost",
+        "-p",
+        "22",
+        "-o",
+        "ConnectTimeout=5",
+        "-o",
+        "ServerAliveInterval=5",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-F",
+        "/dev/null",
+        "oKexAlgorithms=+diffie-hellman-group1-sha1",
+    ]
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="systemssh not supported on windows")
 @pytest.mark.parametrize(
     "eof_msg",
     [
@@ -45,6 +67,10 @@ def test_build_open_cmd():
             b"no matching cipher found, their offer: aes128-cbc,aes256-cbc",
             "No matching cipher found for host localhost, their offer: aes128-cbc,aes256-cbc",
         ),
+        (
+            b"blah blah blah",
+            "Failed to open connection to host localhost. Do you need to disable `auth_strict_key`?",
+        ),
     ],
     ids=[
         "host key verification",
@@ -53,6 +79,7 @@ def test_build_open_cmd():
         "no route to host",
         "no matching cipher",
         "no matching cipher found ciphers",
+        "unknown reason",
     ],
 )
 def test_pty_authentication_error_messages(eof_msg):


### PR DESCRIPTION
- Continued improvement around `SystemSSHTransport` connection/auth failure logging
- Fix for very intermittent issue where pty fd is not available for reading on SystemSSH/Telnet connections, now we loop over the select statement checking the fd instead of failing if it isn't immediately readable
- Implement atexit function if keepalives are enabled -- this originally just lived in the ssh2 transport, but needs to be here in the base `Transport` class as the issue affected all transport types
- Added `send_commands_from_file` method... does what it sounds like it does...
- Added `send_configs_from_file` method (`NetworkDriver` and sub-classes)... also does what it sounds like it does
- Simplified privilege levels and overhauled how auth escalation/deescalation works. Its still probably a bit more complex than it should be, but its a bit more efficient and at least a little simpler/more flexible.
- Removed `comms_prompt_pattern` from Network drivers and now build this as a big pattern matching all of the priv levels for that device type. This is used only for initial connection/finding prompt then scrapli still sets the explicit prompt for the particular privilege level.
- Implemented lru_cache on some places where we have repetitive tasks... probably unmeasurable difference, but in theory its a little faster now in some places
- Moved some Network driver things into the  base `NetworkDriver` class to clean things up a bit.
- Added an `_abort_config` method to abort configurations for IOSXR/Juniper, this is ignored on the other core platforms
- *BREAKING CHANGE*: (minor) Removed now unneeded exception `CouldNotAcquirePrivLevel`
- Made the `get_prompt_pattern` helper a little worse... should revisit to improve/make its use more clear
- Fixed a screw up that had ridiculous transport timeouts -- at one point timeouts were in seconds, then milliseconds... went back to seconds, but left things setting millisecond values... fixed :D 
- Added `transport_options` to base `Scrape` class -- this is a dict of arguments that can be passed down to your selected transport class... for now this is very limited and is just for passing additional "open_cmd" arguments to `SystemSSHTransport`. The current use case is adding args such as ciphers/kex to your ssh command so you don't need to rely on having this in an ssh config file.