### PR TITLE
only decode from bytes -> str in the response object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ CHANGELOG
     (and probably for forever) these will need to be configured in a "special" fashion
 - Updated IOSXE for functional tests to use 16.12.03 -- this includes updates to the base config/expected configs
 ... AFAIK there is some better netconf/restconf support in this version which may be handy for tests for scrapli-netconf
+- Update channel/drivers to never decode bytes -- this now only happens in the response object; primary motivation
+ for this is to not have to decode/re-encode in general, and in scrapli-netconf in particular
 
 # 2020.06.06
 - Converted all priv levels to be kwargs instead of just args for setup -- simple thing but makes it more readable IMO.

--- a/scrapli/channel/async_channel.py
+++ b/scrapli/channel/async_channel.py
@@ -147,7 +147,9 @@ class AsyncChannel(ChannelBase):
                 current_prompt = channel_match.group(0)
                 return current_prompt.decode().strip()
 
-    async def send_input(self, channel_input: str, strip_prompt: bool = True) -> Tuple[str, str]:
+    async def send_input(
+        self, channel_input: str, strip_prompt: bool = True
+    ) -> Tuple[bytes, bytes]:
         """
         Primary entry point to send data to devices in async shell mode; accept input, return result
 
@@ -167,7 +169,7 @@ class AsyncChannel(ChannelBase):
         raw_result, processed_result = await self._async_send_input(
             channel_input=channel_input, strip_prompt=strip_prompt
         )
-        return raw_result.decode(), processed_result.decode()
+        return raw_result, processed_result
 
     @operation_timeout("timeout_ops", "Timed out sending input to device.")
     async def _async_send_input(
@@ -209,7 +211,7 @@ class AsyncChannel(ChannelBase):
     @operation_timeout("timeout_ops", "Timed out sending interactive input to device.")
     async def send_inputs_interact(
         self, interact_events: List[Tuple[str, str, Optional[bool]]]
-    ) -> Tuple[str, str]:
+    ) -> Tuple[bytes, bytes]:
         """
         Async interact with a device with changing prompts per input.
 

--- a/scrapli/channel/base_channel.py
+++ b/scrapli/channel/base_channel.py
@@ -205,7 +205,7 @@ class ChannelBase(ABC):
         if not isinstance(interact_events, list):
             raise TypeError(f"`interact_events` expects a List, got {type(interact_events)}")
 
-    def _post_send_inputs_interact(self, output: bytes) -> Tuple[str, str]:
+    def _post_send_inputs_interact(self, output: bytes) -> Tuple[bytes, bytes]:
         """
         Handle pre "send_inputs_interact" tasks for consistency between sync/async versions
 
@@ -220,6 +220,6 @@ class ChannelBase(ABC):
 
         """
         processed_output = self._restructure_output(output=output, strip_prompt=False)
-        raw_result = output.decode()
-        processed_result = processed_output.decode()
+        raw_result = output
+        processed_result = processed_output
         return raw_result, processed_result

--- a/scrapli/channel/channel.py
+++ b/scrapli/channel/channel.py
@@ -145,7 +145,7 @@ class Channel(ChannelBase):
                 current_prompt = channel_match.group(0)
                 return current_prompt.decode().strip()
 
-    def send_input(self, channel_input: str, strip_prompt: bool = True) -> Tuple[str, str]:
+    def send_input(self, channel_input: str, strip_prompt: bool = True) -> Tuple[bytes, bytes]:
         """
         Primary entry point to send data to devices in shell mode; accept input and returns result
 
@@ -165,7 +165,7 @@ class Channel(ChannelBase):
         raw_result, processed_result = self._send_input(
             channel_input=channel_input, strip_prompt=strip_prompt
         )
-        return raw_result.decode(), processed_result.decode()
+        return raw_result, processed_result
 
     @operation_timeout("timeout_ops", "Timed out sending input to device.")
     def _send_input(self, channel_input: str, strip_prompt: bool) -> Tuple[bytes, bytes]:
@@ -202,7 +202,7 @@ class Channel(ChannelBase):
     @operation_timeout("timeout_ops", "Timed out sending interactive input to device.")
     def send_inputs_interact(
         self, interact_events: List[Tuple[str, str, Optional[bool]]]
-    ) -> Tuple[str, str]:
+    ) -> Tuple[bytes, bytes]:
         """
         Interact with a device with changing prompts per input.
 

--- a/scrapli/driver/base_generic_driver.py
+++ b/scrapli/driver/base_generic_driver.py
@@ -53,7 +53,7 @@ class GenericDriverBase:
 
     @staticmethod
     def _post_send_command(
-        raw_response: str, processed_response: str, response: Response
+        raw_response: bytes, processed_response: bytes, response: Response
     ) -> Response:
         """
         Handle post "send_command" tasks for consistency between sync/async versions
@@ -71,7 +71,7 @@ class GenericDriverBase:
 
         """
         response._record_response(result=processed_response)  # pylint: disable=W0212
-        response.raw_result = raw_response
+        response.raw_result = raw_response.decode()
         return response
 
     @staticmethod

--- a/scrapli/response.py
+++ b/scrapli/response.py
@@ -102,7 +102,7 @@ class Response:
         """
         return f"Response <Success: {str(not self.failed)}>"
 
-    def _record_response(self, result: str) -> None:
+    def _record_response(self, result: bytes) -> None:
         """
         Record channel_input results and elapsed time of channel input/reading output
 
@@ -118,10 +118,10 @@ class Response:
         """
         self.finish_time = datetime.now()
         self.elapsed_time = (self.finish_time - self.start_time).total_seconds()
-        self.result = result
+        self.result = result.decode()
         if not self.failed_when_contains:
             self.failed = False
-        elif not any(err in result for err in self.failed_when_contains):
+        elif not any(err in self.result for err in self.failed_when_contains):
             self.failed = False
 
     def textfsm_parse_output(self, to_dict: bool = True) -> Union[Dict[str, Any], List[Any]]:

--- a/tests/unit/channel/test_async_channel.py
+++ b/tests/unit/channel/test_async_channel.py
@@ -94,8 +94,8 @@ async def test_send_input(async_cisco_iosxe_conn, strip_prompt):
     raw_result, processed_result = await async_cisco_iosxe_conn.channel.send_input(
         channel_input="show version", strip_prompt=strip_prompt
     )
-    assert raw_result == expected_raw
-    assert processed_result == expected_processed
+    assert raw_result == expected_raw.encode()
+    assert processed_result == expected_processed.encode()
 
 
 @pytest.mark.asyncio
@@ -107,5 +107,5 @@ async def test_send_inputs_interact(async_cisco_iosxe_conn):
     raw_result, processed_result = await async_cisco_iosxe_conn.channel.send_inputs_interact(
         interact_events=interact_events
     )
-    assert raw_result == expected_raw
-    assert processed_result == expected_processed
+    assert raw_result == expected_raw.encode()
+    assert processed_result == expected_processed.encode()

--- a/tests/unit/channel/test_base_channel.py
+++ b/tests/unit/channel/test_base_channel.py
@@ -52,8 +52,8 @@ def test_post_send_inputs_interact(sync_cisco_iosxe_conn):
     raw_result, processed_result = sync_cisco_iosxe_conn.channel._post_send_inputs_interact(
         output=expected_raw.encode()
     )
-    assert raw_result == expected_raw
-    assert processed_result[1:] == expected_processed
+    assert raw_result == expected_raw.encode()
+    assert processed_result[1:] == expected_processed.encode()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/channel/test_channel.py
+++ b/tests/unit/channel/test_channel.py
@@ -85,8 +85,8 @@ def test_send_input(sync_cisco_iosxe_conn, strip_prompt):
     raw_result, processed_result = sync_cisco_iosxe_conn.channel.send_input(
         channel_input="show version", strip_prompt=strip_prompt
     )
-    assert raw_result == expected_raw
-    assert processed_result == expected_processed
+    assert raw_result == expected_raw.encode()
+    assert processed_result == expected_processed.encode()
 
 
 def test_send_inputs_interact(sync_cisco_iosxe_conn):
@@ -97,5 +97,5 @@ def test_send_inputs_interact(sync_cisco_iosxe_conn):
     raw_result, processed_result = sync_cisco_iosxe_conn.channel.send_inputs_interact(
         interact_events=interact_events
     )
-    assert raw_result == expected_raw
-    assert processed_result == expected_processed
+    assert raw_result == expected_raw.encode()
+    assert processed_result == expected_processed.encode()

--- a/tests/unit/driver/test_base_generic_driver.py
+++ b/tests/unit/driver/test_base_generic_driver.py
@@ -38,7 +38,7 @@ def test_post_send_command(sync_cisco_iosxe_conn):
         failed_when_contains=["something"],
     )
     final_response = sync_cisco_iosxe_conn._post_send_command(
-        raw_response="blah", processed_response="blahx2", response=response
+        raw_response=b"blah", processed_response=b"blahx2", response=response
     )
     # generic driver doesnt know/care about textfsm_platform
     assert final_response.textfsm_platform == ""

--- a/tests/unit/driver/test_base_network_driver.py
+++ b/tests/unit/driver/test_base_network_driver.py
@@ -173,9 +173,9 @@ def test_pre_send_config(sync_cisco_iosxe_conn):
 
 def test_post_send_config(sync_cisco_iosxe_conn):
     response_one = Response("localhost", "some input", failed_when_contains=["something"])
-    response_one._record_response(result="greatsucccess")
+    response_one._record_response(result=b"greatsucccess")
     response_two = Response("localhost", "some input")
-    response_two._record_response(result="alsosucess")
+    response_two._record_response(result=b"alsosucess")
     multi_response = MultiResponse()
     multi_response.append(response_one)
     multi_response.append(response_two)
@@ -218,7 +218,7 @@ def test_pre_send_configs_user_defined(sync_cisco_iosxe_conn):
 
 def test_post_send_configs(sync_cisco_iosxe_conn):
     response_one = Response("localhost", "some input", failed_when_contains=["something"])
-    response_one._record_response(result="greatsucccess")
+    response_one._record_response(result=b"greatsucccess")
     multi_response = MultiResponse()
     multi_response.append(response_one)
     updated_responses = sync_cisco_iosxe_conn._post_send_configs(responses=multi_response)

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -44,48 +44,48 @@ def test_multi_response():
 def test_response_record_result():
     response = Response("localhost", "ls -al")
     response_end_time = str(datetime.now())[:-7]
-    response_str = """
+    response_bytes = b"""
 ls -al
 total 264
 drwxr-xr-x  34 carl  staff   1088 Jan 27 19:07 ./
 drwxr-xr-x  21 carl  staff    672 Jan 25 15:56 ../
 -rw-r--r--   1 carl  staff  53248 Jan 27 19:07 .coverage
 drwxr-xr-x  12 carl  staff    384 Jan 27 19:13 .git/"""
-    response._record_response(response_str)
+    response._record_response(response_bytes)
     assert str(response.finish_time)[:-7] == response_end_time
-    assert response.result == response_str
+    assert response.result == response_bytes.decode()
     assert response.failed is False
 
 
 def test_response_record_result_failed_when_failed():
     response = Response("localhost", "ls -al", failed_when_contains=["!racecar!"])
     response_end_time = str(datetime.now())[:-7]
-    response_str = """
+    response_bytes = b"""
 ls -al
 total 264
 drwxr-xr-x  34 carl  staff   1088 Jan 27 19:07 ./
 drwxr-xr-x  21 carl  staff    672 Jan 25 15:56 ../
 -rw-r--r--   1 carl  staff  53248 Jan 27 19:07 !racecar!
 drwxr-xr-x  12 carl  staff    384 Jan 27 19:13 .git/"""
-    response._record_response(response_str)
+    response._record_response(response_bytes)
     assert str(response.finish_time)[:-7] == response_end_time
-    assert response.result == response_str
+    assert response.result == response_bytes.decode()
     assert response.failed is True
 
 
 def test_response_record_result_failed_when_success():
     response = Response("localhost", "ls -al", failed_when_contains=["!racecar!"])
     response_end_time = str(datetime.now())[:-7]
-    response_str = """
+    response_bytes = b"""
 ls -al
 total 264
 drwxr-xr-x  34 carl  staff   1088 Jan 27 19:07 ./
 drwxr-xr-x  21 carl  staff    672 Jan 25 15:56 ../
 -rw-r--r--   1 carl  staff  53248 Jan 27 19:07 .coverage
 drwxr-xr-x  12 carl  staff    384 Jan 27 19:13 .git/"""
-    response._record_response(response_str)
+    response._record_response(response_bytes)
     assert str(response.finish_time)[:-7] == response_end_time
-    assert response.result == response_str
+    assert response.result == response_bytes.decode()
     assert response.failed is False
 
 
@@ -112,30 +112,30 @@ def test_response_parse_textfsm(parse_type):
     to_dict = parse_type[0]
     expected_result = parse_type[1]
     response = Response("localhost", channel_input="show ip arp", textfsm_platform="cisco_ios")
-    response_str = """Protocol  Address          Age (min)  Hardware Addr   Type   Interface
+    response_bytes = b"""Protocol  Address          Age (min)  Hardware Addr   Type   Interface
 Internet  172.31.254.1            -   0000.0c07.acfe  ARPA   Vlan254
 Internet  172.31.254.2            -   c800.84b2.e9c2  ARPA   Vlan254
 """
-    response._record_response(response_str)
+    response._record_response(response_bytes)
     assert response.textfsm_parse_output(to_dict=to_dict)[0] == expected_result
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting textfsm on windows")
 def test_response_parse_textfsm_fail():
     response = Response("localhost", channel_input="show ip arp", textfsm_platform="cisco_ios")
-    response_str = ""
-    response._record_response(response_str)
+    response_bytes = b""
+    response._record_response(response_bytes)
     assert response.textfsm_parse_output() == []
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting genie on windows")
 def test_response_parse_genie():
     response = Response("localhost", channel_input="show ip arp", genie_platform="iosxe")
-    response_str = """Protocol  Address          Age (min)  Hardware Addr   Type   Interface
+    response_bytes = b"""Protocol  Address          Age (min)  Hardware Addr   Type   Interface
 Internet  172.31.254.1            -   0000.0c07.acfe  ARPA   Vlan254
 Internet  172.31.254.2            -   c800.84b2.e9c2  ARPA   Vlan254
 """
-    response._record_response(response_str)
+    response._record_response(response_bytes)
     result = response.genie_parse_output()
     assert (
         result["interfaces"]["Vlan254"]["ipv4"]["neighbors"]["172.31.254.1"]["ip"] == "172.31.254.1"
@@ -145,6 +145,6 @@ Internet  172.31.254.2            -   c800.84b2.e9c2  ARPA   Vlan254
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="not supporting genie on windows")
 def test_response_parse_genie_fail():
     response = Response("localhost", channel_input="show ip arp", genie_platform="iosxe")
-    response_str = ""
-    response._record_response(response_str)
+    response_bytes = b""
+    response._record_response(response_bytes)
     assert response.genie_parse_output() == []


### PR DESCRIPTION
convert to bytes only in response object; should be totally transparent for scrapli, but will be nice for scrapli_netconf