### PR TITLE
Develop

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -1,6 +1,6 @@
 name: Commit
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   darglint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ CHANGELOG
  compares a normalized whitespace version of the read output to the a normalized whitespace version of the input
  , fixes [#36](https://github.com/carlmontanari/scrapli/issues/36).
 - Improved system transport ssh error handling -- catch cipher/kex errors better, catch bad configuration messages.
+- Now raise an exception if trying to use an invalid transport class for the base driver type -- i.e. if using
+ asyncssh transport plugin with the "normal" sync driver class.
+- Added links to the other projects in the scrapli "family" to the readme.
 
 # 2020.07.12
 - Fixed a silly issue where `get_prompt` was setting the transport timeout to 10s causing user defined timeouts to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =======
 
+# 2020.XX.XX
+- Fixed the same `get_prompt` issue from the last release, but this time managed to actually fix it in async version!
+- Better handling of `read_until_input` -- stripping some characters out that may get inserted (backspace char), and
+ compares a normalized whitespace version of the read output to the a normalized whitespace version of the input
+ , fixes [#36](https://github.com/carlmontanari/scrapli/issues/36).
+- Improved system transport ssh error handling -- catch cipher/kex errors better, catch bad configuration messages.
+
 # 2020.07.12
 - Fixed a silly issue where `get_prompt` was setting the transport timeout to 10s causing user defined timeouts to be
  effectively ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ CHANGELOG
 - Now raise an exception if trying to use an invalid transport class for the base driver type -- i.e. if using
  asyncssh transport plugin with the "normal" sync driver class.
 - Added links to the other projects in the scrapli "family" to the readme.
+- Created first draft of the scrapli "factory" -- this will allow users to provide the platform name as a string to a
+ single `Scrapli` or `AsyncScrapli` class and it will automagically get the right platform driver selected and such
+ . This is also the first support for `scrapli_community`, which will allow users to contribute non "core" platforms
+  and have them be usable in scrapli just like "normal".
 
 # 2020.07.12
 - Fixed a silly issue where `get_prompt` was setting the transport timeout to 10s causing user defined timeouts to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ CHANGELOG
  single `Scrapli` or `AsyncScrapli` class and it will automagically get the right platform driver selected and such
  . This is also the first support for `scrapli_community`, which will allow users to contribute non "core" platforms
   and have them be usable in scrapli just like "normal".
+- Overhaul decorators for timeouts into a single class (for sync and async), prefer to use signals timeout method
+ where possible, fall back to multiprocessing timeout where required (multiprocessing is slower/more cpu intensive so
+  dont use it if we dont have to).
 
 # 2020.07.12
 - Fixed a silly issue where `get_prompt` was setting the transport timeout to 10s causing user defined timeouts to be

--- a/README.md
+++ b/README.md
@@ -369,7 +369,10 @@ Please also note that the [CHANGELOG](CHANGELOG.md) contains notes about each ve
 
 Assuming you are using scrapli to connect to one of the five "core" platforms, you should almost always use the
  provided corresponding "core" driver. For example if you are connecting to an Arista EOS device, you should use the
-  `EOSDriver`:
+  `EOSDriver`. You can select this driver "manually" or using the scrapli factory `Scrapli` (or the async scrapli
+   factory `AsyncScrapli`).
+
+Importing your driver manually looks like this:
 
 ```python
 from scrapli.driver.core import EOSDriver
@@ -384,20 +387,43 @@ from scrapli.driver.core import AsyncEOSDriver
 
 The core drivers and associated platforms are outlined below:
 
-| Platform/OS   | Scrapli Driver  | Scrapli Async Driver |
-|---------------|-----------------|----------------------|
-| Cisco IOS-XE  | IOSXEDriver     | AsyncIOSXEDriver     | 
-| Cisco NX-OS   | NXOSDriver      | AsyncNXOSDriver      |
-| Cisco IOS-XR  | IOSXRDriver     | AsyncIOSXRDriver     |
-| Arista EOS    | EOSDriver       | AsyncEOSDriver       |
-| Juniper JunOS | JunosDriver     | AsyncJunosDriver     |
+| Platform/OS   | Scrapli Driver  | Scrapli Async Driver | Platform Name |
+|---------------|-----------------|----------------------|---------------|
+| Cisco IOS-XE  | IOSXEDriver     | AsyncIOSXEDriver     | cisco_iosxe   |
+| Cisco NX-OS   | NXOSDriver      | AsyncNXOSDriver      | cisco_nxos    |
+| Cisco IOS-XR  | IOSXRDriver     | AsyncIOSXRDriver     | cisco_iosxr   |
+| Arista EOS    | EOSDriver       | AsyncEOSDriver       | arista_eos    |
+| Juniper JunOS | JunosDriver     | AsyncJunosDriver     | juniper_junos |
 
 All drivers can be imported from `scrapli.driver.core`.
 
-If you are working with a platform not listed above, you have two options: you can use the `Scrape` driver directly
-, which you can read about [here](#using-scrape-directly) or you can use the `GenericDriver` which which you can read
- about [here](#using-the-genericdriver). In general you should probably use the `GenericDriver` and not mess about
-  using `Scrape` directly.
+If you would rather use the factory class to dynamically select the appropriate driver based on a platform string (as
+ seen in the above table), you can do do so as follows:
+
+```python
+from scrapli import Scrapli
+
+device = {
+   "host": "172.18.0.11",
+   "auth_username": "vrnetlab",
+   "auth_password": "VR-netlab9",
+   "auth_strict_key": False,
+   "platform": "cisco_iosxe"
+}
+
+conn = Scrapli(**device)
+conn.open()
+print(conn.get_prompt())
+```
+
+Note that the `Scrapli` and `AsyncScrapli` classes inherit from the `NetworkDriver` and `AsyncNetworkDriver` classes
+ respectively, so all editor code completion and type indicating behavior should work nicely! For non "core
+ " platforms please see the [scrapli_community project]().
+
+If you are working with a platform not listed above (and/or is not in the scrapli community project), you have two
+ options: you can use the `Scrape` driver directly, which you can read about [here](#using-scrape-directly) or you
+  can use the `GenericDriver` which which you can read about [here](#using-the-genericdriver). In general you should
+   probably use the `GenericDriver` and not mess about using `Scrape` directly.
 
 Note: if you are using async you *must* set the transport to `asyncssh` -- this is the only async transport supported
  at this time!

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Feel free to join the very awesome networktocode slack workspace [here](https://
   - [Other Stuff](#other-stuff)
 - [scrapli: What is it](#scrapli-what-is-it)
 - [Supported Platforms](#supported-platforms)
+- [Related Scrapli Libraries](#related-scrapli-libraries)
 - [Advanced Installation](#advanced-installation)
 - [Versioning](#versioning)
 - [Basic Usage](#basic-usage)
@@ -274,6 +275,20 @@ All of this is focused on network device type Telnet/SSH cli interfaces, but sho
 The goal for all "core" devices will be to include functional tests that can run against
 [vrnetlab](https://github.com/plajjan/vrnetlab) containers to ensure that the "core" devices are as thoroughly tested
  as is practical. 
+
+
+# Related Scrapli Libraries
+
+This repo is the "main" or "core" scrapli project, however there are other libraries/repos in the scrapli family
+ -- here is a list/link to all of the other scrapli things!
+
+- [scrapli_paramiko](https://github.com/scrapli/scrapli_paramiko) -- the paramiko transport driver
+- [scrapli_ssh2](https://github.com/scrapli/scrapli_ssh2) -- the ssh2-python transport driver
+- [scrapli_asyncssh](https://github.com/scrapli/scrapli_asyncssh) -- the asyncssh transport driver
+- [scrapli_netconf](https://github.com/scrapli/scrapli_netconf) -- scrapli netconf -- netconf driver built on top of
+ scrapli
+- [nornir_scrapli](https://github.com/scrapli/nornir_scrapli) -- scrapli's nornir plugin
+- [scrapli_stubs](https://github.com/scrapli/scrapli_stubs) -- scrapli type stubs
 
 
 # Advanced Installation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,15 +5,16 @@ mypy>=0.782
 pytest>=5.4.3
 pytest-cov>=2.10.0
 pytest-asyncio>=0.14.0
-pyfakefs>=4.0.2
+pyfakefs>=4.1.0
 pylama>=7.7.1
 pycodestyle>=2.6.0
 pydocstyle>=5.0.2
 pylint>=2.5.3
-darglint>=1.5.1
-pdoc3>=0.8.3 ; sys_platform != "win32"
+darglint>=1.5.2
 asyncssh>=2.2.1
 napalm>=3.0.1
+pdoc3>=0.8.3 ; sys_platform != "win32"
+-e git+https://github.com/scrapli/scrapli_community@master#egg=scrapli_community
 -r requirements.txt
 -r requirements-textfsm.txt
 -r requirements-paramiko.txt

--- a/scrapli/__init__.py
+++ b/scrapli/__init__.py
@@ -7,11 +7,7 @@ from scrapli.driver import AsyncScrape, Scrape
 from scrapli.factory import Scrapli
 
 __version__ = "2020.07.12"
-__all__ = (
-    "AsyncScrape",
-    "Scrape",
-    "Scrapli"
-)
+__all__ = ("AsyncScrape", "Scrape", "Scrapli")
 
 
 class DuplicateFilter(logging.Filter):

--- a/scrapli/__init__.py
+++ b/scrapli/__init__.py
@@ -4,10 +4,10 @@ from logging import getLogger
 from typing import Optional, Tuple
 
 from scrapli.driver import AsyncScrape, Scrape
-from scrapli.factory import Scrapli
+from scrapli.factory import AsyncScrapli, Scrapli
 
 __version__ = "2020.07.12"
-__all__ = ("AsyncScrape", "Scrape", "Scrapli")
+__all__ = ("AsyncScrape", "Scrape", "AsyncScrapli", "Scrapli")
 
 
 class DuplicateFilter(logging.Filter):

--- a/scrapli/__init__.py
+++ b/scrapli/__init__.py
@@ -4,11 +4,13 @@ from logging import getLogger
 from typing import Optional, Tuple
 
 from scrapli.driver import AsyncScrape, Scrape
+from scrapli.factory import Scrapli
 
 __version__ = "2020.07.12"
 __all__ = (
     "AsyncScrape",
     "Scrape",
+    "Scrapli"
 )
 
 

--- a/scrapli/channel/async_channel.py
+++ b/scrapli/channel/async_channel.py
@@ -3,7 +3,7 @@ import re
 from typing import Any, List, Optional, Tuple
 
 from scrapli.channel.base_channel import ChannelBase
-from scrapli.decorators import async_operation_timeout
+from scrapli.decorators import OperationTimeout
 from scrapli.helper import get_prompt_pattern, strip_ansi
 from scrapli.transport.async_transport import AsyncTransport
 
@@ -126,7 +126,7 @@ class AsyncChannel(ChannelBase):
                 self.logger.info(f"Read: {repr(output)}")
                 return output
 
-    @async_operation_timeout("timeout_ops", "Timed out determining prompt on device.")
+    @OperationTimeout("timeout_ops", "Timed out determining prompt on device.")
     async def get_prompt(self) -> str:
         """
         Async get current channel prompt
@@ -177,7 +177,7 @@ class AsyncChannel(ChannelBase):
         )
         return raw_result, processed_result
 
-    @async_operation_timeout("timeout_ops", "Timed out sending input to device.")
+    @OperationTimeout("timeout_ops", "Timed out sending input to device.")
     async def _async_send_input(
         self, channel_input: str, strip_prompt: bool
     ) -> Tuple[bytes, bytes]:
@@ -214,7 +214,7 @@ class AsyncChannel(ChannelBase):
         processed_output = processed_output.lstrip(self.comms_return_char.encode()).rstrip()
         return output, processed_output
 
-    @async_operation_timeout("timeout_ops", "Timed out sending interactive input to device.")
+    @OperationTimeout("timeout_ops", "Timed out sending interactive input to device.")
     async def send_inputs_interact(
         self, interact_events: List[Tuple[str, str, Optional[bool]]]
     ) -> Tuple[bytes, bytes]:

--- a/scrapli/channel/async_channel.py
+++ b/scrapli/channel/async_channel.py
@@ -56,7 +56,7 @@ class AsyncChannel(ChannelBase):
         Async read until all input has been entered.
 
         Args:
-            channel_input: string to write to channel
+            channel_input: bytes to write to channel
             auto_expand: bool to indicate if a device auto-expands commands, for example juniper
                 devices without `cli complete-on-space` disabled will convert `config` to
                 `configuration` after entering a space character after `config`; because scrapli
@@ -82,7 +82,12 @@ class AsyncChannel(ChannelBase):
 
         while True:
             output += await self._read_chunk()
-            if not auto_expand and channel_input in output:
+
+            # replace any backspace chars (particular problem w/ junos), and remove any added spaces
+            # this is just for comparison of the inputs to what was read from channel
+            if not auto_expand and b" ".join(channel_input.split()) in b" ".join(
+                output.replace(b"\x08", b"").split()
+            ):
                 break
             if auto_expand and self._process_auto_expand(
                 output=output, channel_input=channel_input

--- a/scrapli/channel/async_channel.py
+++ b/scrapli/channel/async_channel.py
@@ -134,7 +134,6 @@ class AsyncChannel(ChannelBase):
 
         """
         prompt_pattern = get_prompt_pattern(prompt="", class_prompt=self.comms_prompt_pattern)
-        self.transport.set_timeout(timeout=10)
         self._send_return()
         output = b""
         while True:
@@ -143,7 +142,6 @@ class AsyncChannel(ChannelBase):
                 output = strip_ansi(output=output)
             channel_match = re.search(pattern=prompt_pattern, string=output)
             if channel_match:
-                self.transport.set_timeout()
                 current_prompt = channel_match.group(0)
                 return current_prompt.decode().strip()
 

--- a/scrapli/channel/async_channel.py
+++ b/scrapli/channel/async_channel.py
@@ -80,13 +80,16 @@ class AsyncChannel(ChannelBase):
         if auto_expand is None:
             auto_expand = self.comms_auto_expand
 
+        # squish all channel input words together and cast to lower to make comparison easier
+        processed_channel_input = b"".join(channel_input.lower().split())
+
         while True:
             output += await self._read_chunk()
 
             # replace any backspace chars (particular problem w/ junos), and remove any added spaces
             # this is just for comparison of the inputs to what was read from channel
-            if not auto_expand and b" ".join(channel_input.split()) in b" ".join(
-                output.replace(b"\x08", b"").split()
+            if not auto_expand and processed_channel_input in b"".join(
+                output.lower().replace(b"\x08", b"").split()
             ):
                 break
             if auto_expand and self._process_auto_expand(

--- a/scrapli/channel/channel.py
+++ b/scrapli/channel/channel.py
@@ -54,7 +54,7 @@ class Channel(ChannelBase):
         Read until all input has been entered.
 
         Args:
-            channel_input: string to write to channel
+            channel_input: bytes to write to channel
             auto_expand: bool to indicate if a device auto-expands commands, for example juniper
                 devices without `cli complete-on-space` disabled will convert `config` to
                 `configuration` after entering a space character after `config`; because scrapli
@@ -80,7 +80,12 @@ class Channel(ChannelBase):
 
         while True:
             output += self._read_chunk()
-            if not auto_expand and channel_input in output:
+
+            # replace any backspace chars (particular problem w/ junos), and remove any added spaces
+            # this is just for comparison of the inputs to what was read from channel
+            if not auto_expand and b" ".join(channel_input.split()) in b" ".join(
+                output.replace(b"\x08", b"").split()
+            ):
                 break
             if auto_expand and self._process_auto_expand(
                 output=output, channel_input=channel_input

--- a/scrapli/channel/channel.py
+++ b/scrapli/channel/channel.py
@@ -173,7 +173,7 @@ class Channel(ChannelBase):
         )
         return raw_result, processed_result
 
-    # @operation_timeout("timeout_ops", "Timed out sending input to device.")
+    @operation_timeout("timeout_ops", "Timed out sending input to device.")
     def _send_input(self, channel_input: str, strip_prompt: bool) -> Tuple[bytes, bytes]:
         """
         Send input to device and return results

--- a/scrapli/channel/channel.py
+++ b/scrapli/channel/channel.py
@@ -78,13 +78,16 @@ class Channel(ChannelBase):
         if auto_expand is None:
             auto_expand = self.comms_auto_expand
 
+        # squish all channel input words together and cast to lower to make comparison easier
+        processed_channel_input = b"".join(channel_input.lower().split())
+
         while True:
             output += self._read_chunk()
 
             # replace any backspace chars (particular problem w/ junos), and remove any added spaces
             # this is just for comparison of the inputs to what was read from channel
-            if not auto_expand and b" ".join(channel_input.split()) in b" ".join(
-                output.replace(b"\x08", b"").split()
+            if not auto_expand and processed_channel_input in b"".join(
+                output.lower().replace(b"\x08", b"").split()
             ):
                 break
             if auto_expand and self._process_auto_expand(
@@ -170,7 +173,7 @@ class Channel(ChannelBase):
         )
         return raw_result, processed_result
 
-    @operation_timeout("timeout_ops", "Timed out sending input to device.")
+    # @operation_timeout("timeout_ops", "Timed out sending input to device.")
     def _send_input(self, channel_input: str, strip_prompt: bool) -> Tuple[bytes, bytes]:
         """
         Send input to device and return results

--- a/scrapli/channel/channel.py
+++ b/scrapli/channel/channel.py
@@ -3,7 +3,7 @@ import re
 from typing import Any, List, Optional, Tuple
 
 from scrapli.channel.base_channel import ChannelBase
-from scrapli.decorators import operation_timeout
+from scrapli.decorators import OperationTimeout
 from scrapli.helper import get_prompt_pattern, strip_ansi
 from scrapli.transport.transport import Transport
 
@@ -124,7 +124,7 @@ class Channel(ChannelBase):
                 self.logger.info(f"Read: {repr(output)}")
                 return output
 
-    @operation_timeout("timeout_ops", "Timed out determining prompt on device.")
+    @OperationTimeout("timeout_ops", "Timed out determining prompt on device.")
     def get_prompt(self) -> str:
         """
         Get current channel prompt
@@ -173,7 +173,7 @@ class Channel(ChannelBase):
         )
         return raw_result, processed_result
 
-    @operation_timeout("timeout_ops", "Timed out sending input to device.")
+    @OperationTimeout("timeout_ops", "Timed out sending input to device.")
     def _send_input(self, channel_input: str, strip_prompt: bool) -> Tuple[bytes, bytes]:
         """
         Send input to device and return results
@@ -205,7 +205,7 @@ class Channel(ChannelBase):
         processed_output = processed_output.lstrip(self.comms_return_char.encode()).rstrip()
         return output, processed_output
 
-    @operation_timeout("timeout_ops", "Timed out sending interactive input to device.")
+    @OperationTimeout("timeout_ops", "Timed out sending interactive input to device.")
     def send_inputs_interact(
         self, interact_events: List[Tuple[str, str, Optional[bool]]]
     ) -> Tuple[bytes, bytes]:

--- a/scrapli/decorators.py
+++ b/scrapli/decorators.py
@@ -1,6 +1,9 @@
 """scrapli.decorators"""
 import asyncio
 import multiprocessing.pool
+import signal
+import sys
+import threading
 from typing import TYPE_CHECKING, Any, Callable, Dict, Union
 
 from scrapli.exceptions import ConnectionNotOpened, ScrapliTimeout
@@ -10,151 +13,266 @@ if TYPE_CHECKING:
     from scrapli.channel import Channel  # pragma:  no cover
     from scrapli.transport import Transport  # pragma:  no cover
 
+WIN = sys.platform.startswith("win")
 
-def operation_timeout(attribute: str, message: str = "") -> Callable[..., Any]:
-    """
-    Decorate an "operation" -- raises exception if the operation timeout is exceeded
 
-    Wrap an operation, check class for given attribute and use that for the timeout duration.
+class OperationTimeout:
+    def __init__(self, attribute: str, message: str = "") -> None:
+        """
+        Operation timeout decorator
 
-    Historically this operation timeout decorator used signals instead of the multiprocessing
-    seen here. The signals method was probably a bit more elegant, however there were issues with
-    supporting the system transport as system transport subprocess/ptyprocess components spawn
-    threads of their own, and signals must operate in the main thread.
+        Wrap an operation, check class for given attribute and use that for the timeout duration.
 
-    Args:
-        attribute: attribute to inspect in class (to set timeout duration)
-        message: optional message to pass when decorating a non-standard operation such as telnet
-            login (as opposed to "normal" channel operations)
+        Historically this was not a class and has gone through several iterations... the first
+        iteration was using only signal... this was fast and efficient but did not work on windows
+        and due to system transport spawning a pty/forking things it would not work for that either.
+        Timeouts were then moved to use the multiprocessing method, which works in all cases, and is
+        thread safe (unlike signal), however it is very cpu intensive and slightly slower than the
+        signal method. This current iteration moved the decorator into a class so it is more orderly
+        and easier to break things up into smaller chunks, and importantly now supports both timeout
+        methods -- signal and multiprocessing. This will always try to use the signal method, but if
+        that is not available (due to windows, system transport, or being in not the main thread),
+        it will fallback to the multiprocessing method.
 
-    Returns:
-        decorate: wrapped function
+        Args:
+            attribute: name of attribute to use to get timeout value (set in the decorator)
+            message: optional message to use in timeout exception (set in the decorator)
 
-    Raises:
-        ScrapliTimeout: if timeout exceeded
+        Returns:
+            N/A  # noqa: DAR202
 
-    """
+        Raises:
+            N/A
 
-    def decorate(wrapped_func: Callable[..., Any]) -> Callable[..., Any]:
-        def timeout_wrapper(
-            channel_or_transport: Union["Channel", "Transport"],
-            *args: Any,
-            **kwargs: Dict[str, Union[str, int]],
-        ) -> Any:
-            # import here to avoid circular dependency
-            from scrapli.channel import AsyncChannel, Channel  # pylint: disable=C0415
+        """
+        self.attribute = attribute
+        self.message = message
 
-            timeout_duration = getattr(channel_or_transport, attribute, None)
-            if not timeout_duration:
-                channel_or_transport.logger.info(
-                    f"Could not find {attribute} value of {channel_or_transport}, continuing "
-                    "without timeout decorator"
+        self.scrapli_obj: Union["Channel", "Transport"]
+        self.session_lock: threading.Lock
+        self.close: Callable[..., Any]
+        self.transport: "Transport"
+        self.timeout_duration: int
+        self.timeout_exit: bool = True
+        self.system_transport: bool = True
+        self._use_signals: bool = False
+
+    def __call__(self, wrapped_func: Callable[..., Any]) -> Callable[..., Any]:
+        """
+        Operation timeout decorator
+
+        This is what is called when the decorator is "triggered"
+
+        Args:
+            wrapped_func: function being decorated
+
+        Returns:
+            decorate: decorated func
+
+        Raises:
+            N/A
+
+        """
+        if asyncio.iscoroutinefunction(wrapped_func):
+
+            async def decorate(*args: Any, **kwargs: Any) -> Any:
+                self.scrapli_obj = args[0]
+                self.timeout_duration = getattr(self.scrapli_obj, self.attribute, None)
+
+                if not self.timeout_duration:
+                    self.scrapli_obj.logger.info(
+                        f"Could not find {self.attribute} value of {self.scrapli_obj}, continuing "
+                        "without timeout decorator"
+                    )
+                    return await wrapped_func(*args, **kwargs)
+
+                self.set_scrapli_obj_attrs()
+                return await self.asyncio_timeout(
+                    wrapped_func=wrapped_func, args=args, kwargs=kwargs
                 )
-                return wrapped_func(channel_or_transport, *args, **kwargs)
 
-            # as this can be called from transport or channel get the appropriate objects
-            # to unlock and close the session. we need to unlock as the close will block
-            # forever if the session is locked, and the session very likely is locked while
-            # waiting for output from the device
-            if isinstance(channel_or_transport, (AsyncChannel, Channel)):
-                timeout_exit = channel_or_transport.transport.timeout_exit
-                session_lock = channel_or_transport.transport.session_lock
-                close = channel_or_transport.transport.close
-            else:
-                timeout_exit = channel_or_transport.timeout_exit
-                session_lock = channel_or_transport.session_lock
-                close = channel_or_transport.close
+        else:
 
-            pool = multiprocessing.pool.ThreadPool(processes=1)
-            func_args = [channel_or_transport, *args]
-            future = pool.apply_async(wrapped_func, func_args, kwargs)
-            try:
-                result = future.get(timeout=timeout_duration)
-                pool.terminate()
-                return result
-            except multiprocessing.context.TimeoutError:
-                pool.terminate()
-                channel_or_transport.logger.info(message)
-                if timeout_exit:
-                    channel_or_transport.logger.info("timeout_exit is True, closing transport")
-                    if session_lock.locked():
-                        session_lock.release()
-                    close()
-                raise ScrapliTimeout(message)
+            def decorate(*args: Any, **kwargs: Any) -> Any:  # type: ignore
+                self.scrapli_obj = args[0]
+                self.timeout_duration = getattr(self.scrapli_obj, self.attribute, None)
 
-        return timeout_wrapper
+                if not self.timeout_duration:
+                    self.scrapli_obj.logger.info(
+                        f"Could not find {self.attribute} value of {self.scrapli_obj}, continuing "
+                        "without timeout decorator"
+                    )
+                    return wrapped_func(*args, **kwargs)
 
-    return decorate
+                self.set_scrapli_obj_attrs()
 
-
-def async_operation_timeout(attribute: str, message: str = "") -> Callable[..., Any]:
-    """
-    Decorate an async "operation" -- raises exception if the operation timeout is exceeded
-
-    Wrap an operation, check class for given attribute and use that for the timeout duration. This
-    perhaps could/should just be simply asyncio wait_for, however for consistency purposes and to
-    be sure that the right (timeout) attribute is fetched, and importantly for ensuring that the
-    connection is closed, this is just an async duplication of `operation_timeout`!
-
-    Args:
-        attribute: attribute to inspect in class (to set timeout duration)
-        message: optional message to pass when decorating a non-standard operation such as telnet
-            login (as opposed to "normal" channel operations)
-
-    Returns:
-        decorate: wrapped function
-
-    Raises:
-        ScrapliTimeout: if timeout exceeded
-
-    """
-
-    def decorate(wrapped_func: Callable[..., Any]) -> Callable[..., Any]:
-        async def timeout_wrapper(
-            channel_or_transport: Union["AsyncChannel", "Transport"],
-            *args: Any,
-            **kwargs: Dict[str, Union[str, int]],
-        ) -> Any:
-            # import here to avoid circular dependency
-            from scrapli.channel import AsyncChannel  # pylint: disable=C0415
-
-            timeout_duration = getattr(channel_or_transport, attribute, None)
-            if not timeout_duration:
-                channel_or_transport.logger.info(
-                    f"Could not find {attribute} value of {channel_or_transport}, continuing "
-                    "without timeout decorator"
+                if self._use_signals:
+                    return self.signal_timeout(wrapped_func=wrapped_func, args=args, kwargs=kwargs)
+                return self.multiprocessing_timeout(
+                    wrapped_func=wrapped_func, args=args, kwargs=kwargs
                 )
-                return await wrapped_func(channel_or_transport, *args, **kwargs)
 
-            # as this can be called from transport or channel get the appropriate objects
-            # to unlock and close the session. we need to unlock as the close will block
-            # forever if the session is locked, and the session very likely is locked while
-            # waiting for output from the device
-            if isinstance(channel_or_transport, AsyncChannel):
-                timeout_exit = channel_or_transport.transport.timeout_exit
-                session_lock = channel_or_transport.transport.session_lock
-                close = channel_or_transport.transport.close
-            else:
-                timeout_exit = channel_or_transport.timeout_exit
-                session_lock = channel_or_transport.session_lock
-                close = channel_or_transport.close
+        return decorate
 
-            try:
-                return await asyncio.wait_for(
-                    wrapped_func(channel_or_transport, *args, **kwargs), timeout=timeout_duration
-                )
-            except asyncio.TimeoutError:
-                channel_or_transport.logger.info(message)
-                if timeout_exit:
-                    channel_or_transport.logger.info("timeout_exit is True, closing transport")
-                    if session_lock.locked():
-                        session_lock.release()
-                        close()
-                raise ScrapliTimeout(message)
+    def set_scrapli_obj_attrs(self) -> None:
+        """
+        Parent method to set attributes of wrapped functions class object
 
-        return timeout_wrapper
+        Args:
+            N/A
 
-    return decorate
+        Returns:
+            N/A  # noqa: DAR202
+
+        Raises:
+            N/A
+
+        """
+        from scrapli.channel import AsyncChannel, Channel  # pylint: disable=C0415
+        from scrapli.transport.systemssh import SystemSSHTransport  # pylint: disable=C0415
+
+        if isinstance(self.scrapli_obj, (AsyncChannel, Channel)):
+            self.timeout_exit = self.scrapli_obj.transport.timeout_exit
+            self.session_lock = self.scrapli_obj.transport.session_lock
+            self.close = self.scrapli_obj.transport.close
+            self.transport = self.scrapli_obj.transport
+        else:
+            self.timeout_exit = self.scrapli_obj.timeout_exit
+            self.session_lock = self.scrapli_obj.session_lock
+            self.close = self.scrapli_obj.close
+            self.transport = self.scrapli_obj
+
+        if not isinstance(self.transport, SystemSSHTransport):
+            self.system_transport = False
+
+        if (
+            self.system_transport
+            or WIN
+            or not threading.current_thread() is threading.main_thread()
+        ):
+            self._use_signals = False
+        else:
+            self._use_signals = True
+
+    def _handle_timeout(self) -> None:
+        """
+        Timeout handler method to release locks/raise exception consistently between timeout methods
+
+        Args:
+            N/A
+
+        Returns:
+            N/A  # noqa: DAR202
+
+        Raises:
+            ScrapliTimeout: always, if we hit this method we have already timed out!
+
+        """
+        if self.timeout_exit:
+            self.scrapli_obj.logger.info("timeout_exit is True, closing transport")
+            if self.session_lock.locked():
+                self.session_lock.release()
+            self.close()
+        raise ScrapliTimeout(self.message)
+
+    def _signal_raise_exception(self, signum: Any, frame: Any) -> None:
+        """
+        Signal method exception handler
+
+        Args:
+            signum: singum from the singal handler, unused here
+            frame: frame from the signal handler, unused here
+
+        Returns:
+            N/A  # noqa: DAR202
+
+        Raises:
+            N/A
+
+        """
+        _, _ = signum, frame
+        self._handle_timeout()
+
+    async def asyncio_timeout(
+        self, wrapped_func: Callable[..., Any], args: Any, kwargs: Any
+    ) -> Any:
+        """
+        Asyncio method for timeouts
+
+        Args:
+            wrapped_func: function being decorated
+            args: function being decorated args
+            kwargs: function being decorated kwargs
+
+        Returns:
+            result: result of decorated function
+
+        Raises:
+            N/A
+
+        """
+        try:
+            return await asyncio.wait_for(
+                wrapped_func(*args, **kwargs), timeout=self.timeout_duration
+            )
+        except asyncio.TimeoutError:
+            self._handle_timeout()
+
+    def signal_timeout(self, wrapped_func: Callable[..., Any], args: Any, kwargs: Any) -> Any:
+        """
+        Signal method for timeouts; does not work with system transport, on windows, or in threads
+
+        Perhaps wondering why, if this doesnt work in so many places, do we have it? Great question!
+        Because it is way way way way faster/less cpu intensive than the multiprocessing method!
+
+        Args:
+            wrapped_func: function being decorated
+            args: function being decorated args
+            kwargs: function being decorated kwargs
+
+        Returns:
+            result: result of decorated function
+
+        Raises:
+            N/A
+
+        """
+        old = signal.signal(signal.SIGALRM, self._signal_raise_exception)
+        signal.setitimer(signal.ITIMER_REAL, self.timeout_duration)
+        try:
+            return wrapped_func(*args, **kwargs)
+        finally:
+            if self.timeout_duration:
+                signal.setitimer(signal.ITIMER_REAL, 0)
+                signal.signal(signal.SIGALRM, old)
+
+    def multiprocessing_timeout(
+        self, wrapped_func: Callable[..., Any], args: Any, kwargs: Any
+    ) -> Any:
+        """
+        Multiprocessing method for timeouts; works in threads and on windows
+
+        Args:
+            wrapped_func: function being decorated
+            args: function being decorated args
+            kwargs: function being decorated kwargs
+
+        Returns:
+            result: result of decorated function
+
+        Raises:
+            N/A
+
+        """
+        pool = multiprocessing.pool.ThreadPool(processes=1)
+        future = pool.apply_async(wrapped_func, args, kwargs)
+        try:
+            result = future.get(timeout=self.timeout_duration)
+            pool.terminate()
+            return result
+        except multiprocessing.context.TimeoutError:
+            pool.terminate()
+            self._handle_timeout()
 
 
 def requires_open_session() -> Callable[..., Any]:

--- a/scrapli/decorators.py
+++ b/scrapli/decorators.py
@@ -148,7 +148,7 @@ class OperationTimeout:
         if (
             self.system_transport
             or WIN
-            or not threading.current_thread() is threading.main_thread()
+            or threading.current_thread() is not threading.main_thread()
         ):
             self._use_signals = False
         else:

--- a/scrapli/decorators.py
+++ b/scrapli/decorators.py
@@ -61,7 +61,7 @@ class OperationTimeout:
         """
         Operation timeout decorator
 
-        This is what is called when the decorator is "triggered"
+        This is what is called when the decorator is triggered
 
         Args:
             wrapped_func: function being decorated
@@ -205,7 +205,7 @@ class OperationTimeout:
             kwargs: function being decorated kwargs
 
         Returns:
-            result: result of decorated function
+            Any: result of decorated function
 
         Raises:
             N/A
@@ -231,7 +231,7 @@ class OperationTimeout:
             kwargs: function being decorated kwargs
 
         Returns:
-            result: result of decorated function
+            Any: result of decorated function
 
         Raises:
             N/A
@@ -258,7 +258,7 @@ class OperationTimeout:
             kwargs: function being decorated kwargs
 
         Returns:
-            result: result of decorated function
+            Any: result of decorated function
 
         Raises:
             N/A

--- a/scrapli/driver/async_driver.py
+++ b/scrapli/driver/async_driver.py
@@ -3,7 +3,8 @@ from types import TracebackType
 from typing import Any, Optional, Type
 
 from scrapli.channel import AsyncChannel
-from scrapli.driver.base_driver import ScrapeBase
+from scrapli.driver.base_driver import ASYNCIO_TRANSPORTS, ScrapeBase
+from scrapli.exceptions import TransportPluginError
 
 
 class AsyncScrape(ScrapeBase):
@@ -27,10 +28,17 @@ class AsyncScrape(ScrapeBase):
             N/A  # noqa: DAR202
 
         Raises:
-            N/A
+            TransportPluginError: if attempting to use a non-asyncio transport plugin
 
         """
         super().__init__(**kwargs)
+
+        if self._transport not in ASYNCIO_TRANSPORTS:
+            raise TransportPluginError(
+                f"Attempting to use transport type {self._transport} with an asyncio driver, "
+                f"must use one of {list(ASYNCIO_TRANSPORTS)} transports"
+            )
+
         self.channel = AsyncChannel(transport=self.transport, **self.channel_args)
 
     async def __aenter__(self) -> "AsyncScrape":

--- a/scrapli/driver/base_driver.py
+++ b/scrapli/driver/base_driver.py
@@ -36,6 +36,7 @@ TRANSPORT_BASE_ARGS = (
     "timeout_transport",
     "timeout_exit",
 )
+ASYNCIO_TRANSPORTS = ("asyncssh",)
 
 
 class ScrapeBase:

--- a/scrapli/driver/driver.py
+++ b/scrapli/driver/driver.py
@@ -3,7 +3,8 @@ from types import TracebackType
 from typing import Any, Optional, Type
 
 from scrapli.channel import Channel
-from scrapli.driver.base_driver import ScrapeBase
+from scrapli.driver.base_driver import ASYNCIO_TRANSPORTS, ScrapeBase
+from scrapli.exceptions import TransportPluginError
 
 
 class Scrape(ScrapeBase):
@@ -26,10 +27,17 @@ class Scrape(ScrapeBase):
             N/A  # noqa: DAR202
 
         Raises:
-            N/A
+            TransportPluginError: if attempting to use an asyncio transport plugin
 
         """
         super().__init__(**kwargs)
+
+        if self._transport in ASYNCIO_TRANSPORTS:
+            raise TransportPluginError(
+                f"Attempting to use transport type {self._transport} with a sync driver, "
+                "must use a non-asyncio transport"
+            )
+
         self.channel = Channel(transport=self.transport, **self.channel_args)
 
     def __enter__(self) -> "Scrape":

--- a/scrapli/factory.py
+++ b/scrapli/factory.py
@@ -152,6 +152,7 @@ def _get_driver(
 
     Args:
         platform: name of target platform; i.e. `cisco_iosxe`, `arista_eos`, etc.
+        variant: name of the target paltform variant
         _async: True/False this is for an asyncio transport driver
 
     Returns:

--- a/scrapli/factory.py
+++ b/scrapli/factory.py
@@ -4,6 +4,7 @@ from logging import getLogger
 from typing import Any, Dict
 
 from scrapli.driver import NetworkDriver
+from scrapli.driver.base_driver import ASYNCIO_TRANSPORTS
 from scrapli.exceptions import ScrapliException
 
 LOG = getLogger("scrapli.factory")
@@ -86,6 +87,9 @@ class Scrapli(NetworkDriver):
 
         """
         LOG.debug("Scrapli factory initialized")
+
+        if kwargs.get("transport", "system") in ASYNCIO_TRANSPORTS:
+            raise ScrapliException("Use `AsyncScrapli` if using an async transport!")
 
         if "platform" not in kwargs.keys():
             msg = "Argument `platform` must be provided when using `Scrapli` factory!"

--- a/scrapli/factory.py
+++ b/scrapli/factory.py
@@ -37,7 +37,7 @@ def _get_core_driver(driver: str) -> NetworkDriver:
         )
         return final_driver
     except Exception as exc:
-        msg = f"Error importing core driver `{driver}`; exception: {exc}"
+        msg = f"Error importing core driver `{driver}`; exception: `{exc}`"
         LOG.exception(msg)
         raise ScrapliException(msg)
 

--- a/scrapli/factory.py
+++ b/scrapli/factory.py
@@ -25,7 +25,7 @@ def _get_core_driver(driver: str) -> NetworkDriver:
         driver: Name of driver to get
 
     Returns:
-        final_driver: final driver class
+        NetworkDriver: final driver class
 
     Raises:
         ScrapliException: if any issue getting core driver
@@ -50,7 +50,7 @@ def _get_driver(driver: str) -> NetworkDriver:
         driver: Name of driver to get
 
     Returns:
-        final_driver: final driver class
+        NetworkDriver: final driver class
 
     Raises:
         ScrapliException: if `platform` not in core drivers - community platforms coming soon!
@@ -74,6 +74,7 @@ class Scrapli(NetworkDriver):
         Scrapli Factory method for synchronous drivers
 
         Args:
+            cls: class object
             **kwargs: keyword arguments to pass to selected driver class plus the additional
                 `driver` keyword argument which should match a core or community driver name!
 

--- a/scrapli/factory.py
+++ b/scrapli/factory.py
@@ -1,0 +1,99 @@
+"""scrapli.factory"""
+import importlib
+from logging import getLogger
+from typing import Any, Dict
+
+from scrapli.driver import NetworkDriver
+from scrapli.exceptions import ScrapliException
+
+LOG = getLogger("scrapli.factory")
+
+CORE_PLATFORM_MAP = {
+    "arista_eos": "EOSDriver",
+    "cisco_iosxe": "IOSXEDriver",
+    "cisco_iosxr": "IOSXRDriver",
+    "cisco_nxos": "NXOSDriver",
+    "juniper_junos": "JunosDriver",
+}
+
+
+def _get_core_driver(driver: str) -> NetworkDriver:
+    """
+    Get core driver
+
+    Args:
+        driver: Name of driver to get
+
+    Returns:
+        final_driver: final driver class
+
+    Raises:
+        ScrapliException: if any issue getting core driver
+
+    """
+    try:
+        final_driver: NetworkDriver = getattr(
+            importlib.import_module(name="scrapli.driver.core"), driver
+        )
+        return final_driver
+    except Exception as exc:
+        msg = f"Error importing core driver `{driver}`; exception: {exc}"
+        LOG.exception(msg)
+        raise ScrapliException(msg)
+
+
+def _get_driver(driver: str) -> NetworkDriver:
+    """
+    Parent get driver method
+
+    Args:
+        driver: Name of driver to get
+
+    Returns:
+        final_driver: final driver class
+
+    Raises:
+        ScrapliException: if `platform` not in core drivers - community platforms coming soon!
+
+    """
+    core_driver = CORE_PLATFORM_MAP.get(driver, None)
+
+    if core_driver:
+        final_driver = _get_core_driver(driver=core_driver)
+        msg = f"Driver `{final_driver}` selected from scrapli core drivers"
+    else:
+        raise ScrapliException("Community platform support/factory coming soon!")
+
+    LOG.info(msg)
+    return final_driver
+
+
+class Scrapli(NetworkDriver):
+    def __new__(cls, **kwargs: Dict[Any, Any]) -> "Scrapli":
+        """
+        Scrapli Factory method for synchronous drivers
+
+        Args:
+            **kwargs: keyword arguments to pass to selected driver class plus the additional
+                `driver` keyword argument which should match a core or community driver name!
+
+        Returns:
+            final_driver: synchronous driver class for provided driver
+
+        Raises:
+            ScrapliException: if `platform` not in keyword arguments
+
+        """
+        LOG.debug("Scrapli factory initialized")
+
+        if "platform" not in kwargs.keys():
+            msg = "Argument `platform` must be provided when using `Scrapli` factory!"
+            LOG.exception(msg)
+            raise ScrapliException(msg)
+        driver = kwargs.pop("platform")
+
+        if not isinstance(driver, str):
+            raise ScrapliException(f"Argument `platform` must be `str` got `{type(driver)}`")
+
+        final_driver = _get_driver(driver=driver)
+        return final_driver(**kwargs)

--- a/scrapli/factory.py
+++ b/scrapli/factory.py
@@ -1,88 +1,206 @@
 """scrapli.factory"""
 import importlib
+from copy import deepcopy
 from logging import getLogger
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple, Type, Union
 
-from scrapli.driver import NetworkDriver
+from scrapli.driver import AsyncGenericDriver, AsyncNetworkDriver, GenericDriver, NetworkDriver
 from scrapli.driver.base_driver import ASYNCIO_TRANSPORTS
+from scrapli.driver.core import (
+    AsyncEOSDriver,
+    AsyncIOSXEDriver,
+    AsyncIOSXRDriver,
+    AsyncJunosDriver,
+    AsyncNXOSDriver,
+    EOSDriver,
+    IOSXEDriver,
+    IOSXRDriver,
+    JunosDriver,
+    NXOSDriver,
+)
 from scrapli.exceptions import ScrapliException
 
 LOG = getLogger("scrapli.factory")
 
-CORE_PLATFORM_MAP = {
-    "arista_eos": "EOSDriver",
-    "cisco_iosxe": "IOSXEDriver",
-    "cisco_iosxr": "IOSXRDriver",
-    "cisco_nxos": "NXOSDriver",
-    "juniper_junos": "JunosDriver",
+ASYNC_CORE_PLATFORM_MAP = {
+    "arista_eos": AsyncEOSDriver,
+    "cisco_iosxe": AsyncIOSXEDriver,
+    "cisco_iosxr": AsyncIOSXRDriver,
+    "cisco_nxos": AsyncNXOSDriver,
+    "juniper_junos": AsyncJunosDriver,
 }
+SYNC_CORE_PLATFORM_MAP = {
+    "arista_eos": EOSDriver,
+    "cisco_iosxe": IOSXEDriver,
+    "cisco_iosxr": IOSXRDriver,
+    "cisco_nxos": NXOSDriver,
+    "juniper_junos": JunosDriver,
+}
+ASYNC_DRIVER_MAP = {"network": AsyncNetworkDriver, "generic": AsyncGenericDriver}
+SYNC_DRIVER_MAP = {"network": NetworkDriver, "generic": GenericDriver}
 
 
-def _get_core_driver(driver: str) -> NetworkDriver:
-    """
-    Get core driver
-
-    Args:
-        driver: Name of driver to get
-
-    Returns:
-        NetworkDriver: final driver class
-
-    Raises:
-        ScrapliException: if any issue getting core driver
-
-    """
-    try:
-        final_driver: NetworkDriver = getattr(
-            importlib.import_module(name="scrapli.driver.core"), driver
-        )
-        return final_driver
-    except Exception as exc:
-        msg = f"Error importing core driver `{driver}`; exception: `{exc}`"
-        LOG.exception(msg)
-        raise ScrapliException(msg)
-
-
-def _get_driver(driver: str) -> NetworkDriver:
+def _get_community_platform_details(community_platform_name: str) -> Dict[str, Any]:
     """
     Parent get driver method
 
     Args:
-        driver: Name of driver to get
+        community_platform_name: name of community
+
+    Returns:
+        platform_details: dict of details about community platform from scrapli_community library
+
+    Raises:
+        ModuleNotFoundError: if scrapli_community is not importable
+        ScrapliException: if community platform is missing "SCRAPLI_PLATFORM" attribute
+        ScrapliException: for any unknown exception during community platform import
+
+    """
+    try:
+        # replace any underscores in platform name with "."; should support any future platforms
+        # that dont have "child" os types -- i.e. just "cisco" instead of "cisco_iosxe"
+        scrapli_community_platform = importlib.import_module(
+            name=f"scrapli_community.{community_platform_name.replace('_', '.')}"
+        )
+    except ModuleNotFoundError as exc:
+        err = f"Module '{exc.name}' not found!"
+        msg = f"***** {err} {'*' * (80 - len(err))}"
+        fix = (
+            "To resolve this issue, ensure you have the scrapli community package installed."
+            " You can install this with pip: `pip install scrapli_community`."
+        )
+        warning = "\n" + msg + "\n" + fix + "\n" + msg
+        raise ModuleNotFoundError(warning)
+    except Exception as exc:
+        msg = f"Unknown error occurred, exception: {exc}"
+        raise ScrapliException(msg)
+
+    platform_details_original = getattr(scrapli_community_platform, "SCRAPLI_PLATFORM", {})
+    if not platform_details_original:
+        msg = "Community platform missing required attribute `SCRAPLI_PLATFORM`"
+        raise ScrapliException(msg)
+    platform_details: Dict[str, Any] = deepcopy(platform_details_original)
+    return platform_details
+
+
+def _get_community_driver(
+    community_platform_name: str, variant: Optional[str], _async: bool = False
+) -> Tuple[
+    Union[
+        Type[AsyncNetworkDriver], Type[AsyncGenericDriver], Type[NetworkDriver], Type[GenericDriver]
+    ],
+    Dict[str, Any],
+]:
+    """
+    Parent get driver method
+
+    Args:
+        community_platform_name: name of community
+        variant: optional name of variant of community platform
+        _async: True/False this is for an asyncio transport driver
 
     Returns:
         NetworkDriver: final driver class
 
     Raises:
-        ScrapliException: if `platform` not in core drivers - community platforms coming soon!
+        ScrapliException: if scrapli_community platform has an invalid value for "driver_type"
 
     """
-    core_driver = CORE_PLATFORM_MAP.get(driver, None)
+    platform_details = _get_community_platform_details(
+        community_platform_name=community_platform_name
+    )
 
-    if core_driver:
-        final_driver = _get_core_driver(driver=core_driver)
+    driver_type = platform_details["driver_type"]
+    if _async is False:
+        final_driver = SYNC_DRIVER_MAP.get(driver_type, None)
+    else:
+        final_driver = ASYNC_DRIVER_MAP.get(driver_type, None)
+    if not final_driver:
+        raise ScrapliException("Invalid driver type provided in community platform data")
+
+    platform_kwargs = platform_details["defaults"]
+
+    if variant:
+        variant_kwargs = platform_details["variants"][variant]
+        final_platform_kwargs = {**platform_kwargs, **variant_kwargs}
+    else:
+        final_platform_kwargs = platform_kwargs
+
+    if not _async:
+        # remove unnecessary asyncio things
+        final_platform_kwargs.pop("async_on_open")
+        final_platform_kwargs.pop("async_on_close")
+        # rename sync_on_(open|close) keys to just "on_open"/"on_close"
+        final_platform_kwargs["on_open"] = final_platform_kwargs.pop("sync_on_open")
+        final_platform_kwargs["on_close"] = final_platform_kwargs.pop("sync_on_close")
+    else:
+        # remove unnecessary sync things
+        final_platform_kwargs.pop("sync_on_open")
+        final_platform_kwargs.pop("sync_on_close")
+        # rename sync_on_(open|close) keys to just "on_open"/"on_close"
+        final_platform_kwargs["on_open"] = final_platform_kwargs.pop("async_on_open")
+        final_platform_kwargs["on_close"] = final_platform_kwargs.pop("async_on_close")
+
+    return final_driver, final_platform_kwargs
+
+
+def _get_driver(
+    platform: str, variant: Optional[str], _async: bool = False
+) -> Tuple[Union[Type[NetworkDriver], Type[GenericDriver]], Dict[str, Any]]:
+    """
+    Parent get driver method
+
+    Args:
+        platform: name of target platform; i.e. `cisco_iosxe`, `arista_eos`, etc.
+        _async: True/False this is for an asyncio transport driver
+
+    Returns:
+        NetworkDriver: final driver class; generally NetworkDriver, but for some community platforms
+            could be GenericDriver
+
+    Raises:
+        N/A
+
+    """
+    additional_kwargs: Dict[str, Any] = {}
+
+    if platform in SYNC_CORE_PLATFORM_MAP:
+        if _async is False:
+            final_driver = SYNC_CORE_PLATFORM_MAP[platform]
+        else:
+            final_driver = ASYNC_CORE_PLATFORM_MAP[platform]
         msg = f"Driver `{final_driver}` selected from scrapli core drivers"
     else:
-        raise ScrapliException("Community platform support/factory coming soon!")
+        final_driver, additional_kwargs = _get_community_driver(
+            community_platform_name=platform, variant=variant, _async=_async
+        )
+        msg = (
+            f"Driver `{final_driver}` selected from scrapli community platforms, with the following"
+            f" platform arguments: `{additional_kwargs}`"
+        )
 
     LOG.info(msg)
-    return final_driver
+    return final_driver, additional_kwargs
 
 
 class Scrapli(NetworkDriver):
-    def __new__(cls, **kwargs: Dict[Any, Any]) -> "Scrapli":
+    def __new__(
+        cls, platform: str, variant: Optional[str] = None, **kwargs: Dict[Any, Any]
+    ) -> "Scrapli":
         """
         Scrapli Factory method for synchronous drivers
 
         Args:
             cls: class object
-            **kwargs: keyword arguments to pass to selected driver class plus the additional
-                `driver` keyword argument which should match a core or community driver name!
+            platform: name of target platform; i.e. `cisco_iosxe`, `arista_eos`, etc.
+            variant: optional name of variant of community platform
+            **kwargs: keyword arguments to pass to selected driver class
 
         Returns:
             final_driver: synchronous driver class for provided driver
 
         Raises:
+            ScrapliException: if provided transport is asyncio
             ScrapliException: if `platform` not in keyword arguments
 
         """
@@ -91,14 +209,65 @@ class Scrapli(NetworkDriver):
         if kwargs.get("transport", "system") in ASYNCIO_TRANSPORTS:
             raise ScrapliException("Use `AsyncScrapli` if using an async transport!")
 
-        if "platform" not in kwargs.keys():
-            msg = "Argument `platform` must be provided when using `Scrapli` factory!"
-            LOG.exception(msg)
-            raise ScrapliException(msg)
-        driver = kwargs.pop("platform")
+        if not isinstance(platform, str):
+            raise ScrapliException(f"Argument `platform` must be `str` got `{type(platform)}`")
 
-        if not isinstance(driver, str):
-            raise ScrapliException(f"Argument `platform` must be `str` got `{type(driver)}`")
+        final_driver, additional_kwargs = _get_driver(
+            platform=platform, variant=variant, _async=False
+        )
 
-        final_driver = _get_driver(driver=driver)
-        return final_driver(**kwargs)
+        # at this point will need to merge the additional kwargs in (for community drivers),
+        # ensure that kwargs passed by user supersede the ones coming from community platform
+        if additional_kwargs:
+            final_kwargs = {**additional_kwargs, **kwargs}
+        else:
+            final_kwargs = kwargs
+
+        # mypy was displeased about NetworkDriver not being callable, fix later probably :)
+        final_conn: "Scrapli" = final_driver(**final_kwargs)  # type: ignore
+        return final_conn
+
+
+class AsyncScrapli(AsyncNetworkDriver):
+    def __new__(
+        cls, platform: str, variant: Optional[str] = None, **kwargs: Dict[Any, Any]
+    ) -> "AsyncScrapli":
+        """
+        Scrapli Factory method for asynchronous drivers
+
+        Args:
+            cls: class object
+            platform: name of target platform; i.e. `cisco_iosxe`, `arista_eos`, etc.
+            variant: optional name of variant of community platform
+            **kwargs: keyword arguments to pass to selected driver class
+
+        Returns:
+            final_driver: synchronous driver class for provided driver
+
+        Raises:
+            ScrapliException: if provided transport is not asyncio
+            ScrapliException: if `platform` not in keyword arguments
+
+        """
+        LOG.debug("Scrapli factory initialized")
+
+        if kwargs.get("transport", "system") not in ASYNCIO_TRANSPORTS:
+            raise ScrapliException("Use `Scrapli` if using a synchronous transport!")
+
+        if not isinstance(platform, str):
+            raise ScrapliException(f"Argument `platform` must be `str` got `{type(platform)}`")
+
+        final_driver, additional_kwargs = _get_driver(
+            platform=platform, variant=variant, _async=True
+        )
+
+        # at this point will need to merge the additional kwargs in (for community drivers),
+        # ensure that kwargs passed by user supersede the ones coming from community platform
+        if additional_kwargs:
+            final_kwargs = {**additional_kwargs, **kwargs}
+        else:
+            final_kwargs = kwargs
+
+        # mypy was displeased about NetworkDriver not being callable, fix later probably :)
+        final_conn: "AsyncScrapli" = final_driver(**final_kwargs)  # type: ignore
+        return final_conn

--- a/scrapli/transport/systemssh.py
+++ b/scrapli/transport/systemssh.py
@@ -3,7 +3,7 @@ import re
 from select import select
 from typing import Any, Dict, Optional
 
-from scrapli.decorators import operation_timeout, requires_open_session
+from scrapli.decorators import OperationTimeout, requires_open_session
 from scrapli.exceptions import ScrapliAuthenticationFailed
 from scrapli.helper import get_prompt_pattern, strip_ansi
 from scrapli.ssh_config import SSHConfig
@@ -357,7 +357,7 @@ class SystemSSHTransport(Transport):
         self.logger.debug(f"Authenticated to host {self.host} with password")
         return True
 
-    @operation_timeout("_timeout_ops", "Timed out attempting to authenticate")
+    @OperationTimeout("_timeout_ops", "Timed out attempting to authenticate")
     def _authenticate(self) -> None:
         """
         Private method to check initial authentication when using pty_session
@@ -421,7 +421,7 @@ class SystemSSHTransport(Transport):
                 self.session_lock.release()
                 break
 
-    @operation_timeout("_timeout_ops", "Timed out determining if session is authenticated")
+    @OperationTimeout("_timeout_ops", "Timed out determining if session is authenticated")
     def _system_isauthenticated(self) -> bool:
         """
         Check if session is authenticated
@@ -527,7 +527,7 @@ class SystemSSHTransport(Transport):
         return False
 
     @requires_open_session()
-    @operation_timeout("timeout_transport", "Timed out reading from transport")
+    @OperationTimeout("timeout_transport", "Timed out reading from transport")
     def read(self) -> bytes:
         """
         Read data from the channel
@@ -546,7 +546,7 @@ class SystemSSHTransport(Transport):
         return self.session.read(read_bytes)
 
     @requires_open_session()
-    @operation_timeout("timeout_transport", "Timed out writing to transport")
+    @OperationTimeout("timeout_transport", "Timed out writing to transport")
     def write(self, channel_input: str) -> None:
         """
         Write data to the channel

--- a/scrapli/transport/systemssh.py
+++ b/scrapli/transport/systemssh.py
@@ -280,7 +280,7 @@ class SystemSSHTransport(Transport):
             msg = f"Timed out connecting to host {self.host}"
         elif b"no route to host" in output.lower():
             msg = f"No route to host {self.host}"
-        elif b"no matching key exchange found" in output.lower():
+        elif b"no matching key exchange" in output.lower():
             msg = f"No matching key exchange found for host {self.host}"
             key_exchange_pattern = re.compile(
                 pattern=rb"their offer: ([a-z0-9\-,]*)", flags=re.M | re.I
@@ -292,7 +292,7 @@ class SystemSSHTransport(Transport):
                     f"No matching key exchange found for host {self.host}, their offer: "
                     f"{offered_key_exchanges}"
                 )
-        elif b"no matching cipher found" in output.lower():
+        elif b"no matching cipher" in output.lower():
             msg = f"No matching cipher found for host {self.host}"
             ciphers_pattern = re.compile(pattern=rb"their offer: ([a-z0-9\-,]*)", flags=re.M | re.I)
             offered_ciphers_match = re.search(pattern=ciphers_pattern, string=output)
@@ -301,6 +301,13 @@ class SystemSSHTransport(Transport):
                 msg = (
                     f"No matching cipher found for host {self.host}, their offer: {offered_ciphers}"
                 )
+        elif b"bad configuration" in output.lower():
+            msg = f"Bad SSH configuration option(s) for host {self.host}"
+            configuration_pattern = re.compile(pattern=rb"bad configuration option: ([a-z0-9\+\=,]*)", flags=re.M | re.I)
+            configuration_issue_match = re.search(pattern=configuration_pattern, string=output)
+            if configuration_issue_match:
+                configuration_issues = configuration_issue_match.group(1).decode()
+                msg = f"Bad SSH configuration option(s) for host {self.host}, bad option(s): {configuration_issues}"
         elif b"WARNING: UNPROTECTED PRIVATE KEY FILE!" in output:
             msg = (
                 f"Permissions for private key `{self.auth_private_key}` are too open, "

--- a/scrapli/transport/systemssh.py
+++ b/scrapli/transport/systemssh.py
@@ -303,11 +303,16 @@ class SystemSSHTransport(Transport):
                 )
         elif b"bad configuration" in output.lower():
             msg = f"Bad SSH configuration option(s) for host {self.host}"
-            configuration_pattern = re.compile(pattern=rb"bad configuration option: ([a-z0-9\+\=,]*)", flags=re.M | re.I)
+            configuration_pattern = re.compile(
+                pattern=rb"bad configuration option: ([a-z0-9\+\=,]*)", flags=re.M | re.I
+            )
             configuration_issue_match = re.search(pattern=configuration_pattern, string=output)
             if configuration_issue_match:
                 configuration_issues = configuration_issue_match.group(1).decode()
-                msg = f"Bad SSH configuration option(s) for host {self.host}, bad option(s): {configuration_issues}"
+                msg = (
+                    f"Bad SSH configuration option(s) for host {self.host}, bad option(s): "
+                    f"{configuration_issues}"
+                )
         elif b"WARNING: UNPROTECTED PRIVATE KEY FILE!" in output:
             msg = (
                 f"Permissions for private key `{self.auth_private_key}` are too open, "

--- a/scrapli/transport/telnet.py
+++ b/scrapli/transport/telnet.py
@@ -5,7 +5,7 @@ from select import select
 from telnetlib import Telnet
 from typing import Optional
 
-from scrapli.decorators import operation_timeout, requires_open_session
+from scrapli.decorators import OperationTimeout, requires_open_session
 from scrapli.exceptions import ScrapliAuthenticationFailed
 from scrapli.helper import get_prompt_pattern, strip_ansi
 from scrapli.transport.transport import Transport
@@ -208,7 +208,7 @@ class TelnetTransport(Transport):
         self.logger.debug(f"Authenticated to host {self.host} with password")
         self.session = telnet_session
 
-    @operation_timeout("_timeout_ops_auth", "Timed out looking for telnet login prompts")
+    @OperationTimeout("_timeout_ops_auth", "Timed out looking for telnet login prompts")
     def _authenticate(self, telnet_session: ScrapliTelnet) -> None:
         """
         Parent private method to handle telnet authentication
@@ -252,7 +252,7 @@ class TelnetTransport(Transport):
                     telnet_session.write(self._comms_return_char.encode())
                     return_attempts += 1
 
-    @operation_timeout("_timeout_ops_auth", "Timed determining if telnet session is authenticated")
+    @OperationTimeout("_timeout_ops_auth", "Timed determining if telnet session is authenticated")
     def _telnet_isauthenticated(self, telnet_session: ScrapliTelnet) -> bool:
         """
         Check if session is authenticated
@@ -342,7 +342,7 @@ class TelnetTransport(Transport):
         return False
 
     @requires_open_session()
-    @operation_timeout("timeout_transport", "Timed out reading from transport")
+    @OperationTimeout("timeout_transport", "Timed out reading from transport")
     def read(self) -> bytes:
         """
         Read data from the channel
@@ -360,7 +360,7 @@ class TelnetTransport(Transport):
         return self.session.read_eager()
 
     @requires_open_session()
-    @operation_timeout("timeout_transport", "Timed out writing to transport")
+    @OperationTimeout("timeout_transport", "Timed out writing to transport")
     def write(self, channel_input: str) -> None:
         """
         Write data to the channel

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -45,7 +45,7 @@ def mock_cisco_iosxe_server():
     pool.submit(start_server, "cisco_iosxe")
     # yield to let all the tests run, then we can deal w/ cleaning up the thread/loop
     yield
-    SERVER_LOOP.call_soon_threadsafe(SERVER_LOOP.stop())
+    SERVER_LOOP.call_soon_threadsafe(SERVER_LOOP.stop)
     pool.shutdown()
 
 

--- a/tests/unit/driver/core/cisco_nxos/test_async_driver.py
+++ b/tests/unit/driver/core/cisco_nxos/test_async_driver.py
@@ -1,6 +1,0 @@
-from scrapli.driver.core import AsyncNXOSDriver
-
-
-def test_nxos_async_driver_init_telnet():
-    conn = AsyncNXOSDriver(host="myhost", transport="telnet")
-    assert conn.transport.username_prompt == "login:"

--- a/tests/unit/driver/core/juniper_junos/test_async_driver.py
+++ b/tests/unit/driver/core/juniper_junos/test_async_driver.py
@@ -1,6 +1,0 @@
-from scrapli.driver.core import AsyncJunosDriver
-
-
-def test_junos_async_driver_init_telnet():
-    conn = AsyncJunosDriver(host="myhost", transport="telnet")
-    assert conn.transport.username_prompt == "login:"

--- a/tests/unit/driver/core/test_common_async_driver.py
+++ b/tests/unit/driver/core/test_common_async_driver.py
@@ -51,7 +51,7 @@ def test_core_driver_init(platform, attr_setup):
     driver = platform[0]
     on_close = driver_args["on_close"] or platform[1]
     on_open = driver_args["on_open"] or platform[2]
-    conn = driver(host="myhost", **driver_args)
+    conn = driver(host="myhost", transport="asyncssh", **driver_args)
     assert conn.auth_secondary == driver_args["auth_secondary"]
     assert conn.on_open == on_open
     assert conn.on_close == on_close

--- a/tests/unit/driver/test_async_driver.py
+++ b/tests/unit/driver/test_async_driver.py
@@ -1,6 +1,7 @@
 import pytest
 
 from scrapli.driver.core import AsyncIOSXEDriver
+from scrapli.exceptions import TransportPluginError
 
 from ...test_data.devices import DEVICES
 
@@ -19,3 +20,14 @@ async def test_transport_bool(async_cisco_iosxe_conn):
     assert bool(async_cisco_iosxe_conn.transport) is True
     await async_cisco_iosxe_conn.close()
     assert bool(async_cisco_iosxe_conn.transport) is False
+
+
+@pytest.mark.asyncio
+async def test_non_async_transport():
+    device = DEVICES["mock_cisco_iosxe"].copy()
+    with pytest.raises(TransportPluginError) as exc:
+        AsyncIOSXEDriver(transport="system", **device)
+    assert (
+        str(exc.value)
+        == "Attempting to use transport type system with an asyncio driver, must use one of ['asyncssh'] transports"
+    )

--- a/tests/unit/driver/test_async_network_driver.py
+++ b/tests/unit/driver/test_async_network_driver.py
@@ -15,7 +15,9 @@ TEST_DATA_DIR = f"{Path(scrapli.__file__).parents[1]}/tests/test_data"
 
 def test_check_kwargs_comms_prompt_pattern():
     with pytest.warns(UserWarning) as warn:
-        conn = AsyncIOSXEDriver(host="localhost", comms_prompt_pattern="something")
+        conn = AsyncIOSXEDriver(
+            host="localhost", transport="asyncssh", comms_prompt_pattern="something"
+        )
     assert (
         conn.comms_prompt_pattern
         == "(^[a-z0-9.\\-_@()/:]{1,63}>$)|(^[a-z0-9.\\-_@/:]{1,63}#$)|(^[a-z0-9.\\-_@/:]{1,63}\\(conf[a-z0-9.\\-@/:\\+]{"

--- a/tests/unit/driver/test_driver.py
+++ b/tests/unit/driver/test_driver.py
@@ -1,3 +1,11 @@
+import pytest
+
+from scrapli.driver.core import IOSXEDriver
+from scrapli.exceptions import TransportPluginError
+
+from ...test_data.devices import DEVICES
+
+
 def test_context_manager(sync_cisco_iosxe_conn):
     with sync_cisco_iosxe_conn as conn:
         assert conn.isalive() is True
@@ -16,3 +24,13 @@ def test_transport_encrypted_private_key(sync_cisco_iosxe_conn_encrypted_key):
     assert bool(sync_cisco_iosxe_conn_encrypted_key.transport) is True
     sync_cisco_iosxe_conn_encrypted_key.close()
     assert bool(sync_cisco_iosxe_conn_encrypted_key.transport) is False
+
+
+def test_non_sync_transport():
+    device = DEVICES["mock_cisco_iosxe"].copy()
+    with pytest.raises(TransportPluginError) as exc:
+        IOSXEDriver(transport="asyncssh", **device)
+    assert (
+        str(exc.value)
+        == "Attempting to use transport type asyncssh with a sync driver, must use a non-asyncio transport"
+    )

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -4,7 +4,7 @@ from threading import Lock
 
 import pytest
 
-from scrapli.decorators import async_operation_timeout, operation_timeout, requires_open_session
+from scrapli.decorators import OperationTimeout, requires_open_session
 from scrapli.driver.base_driver import ScrapeBase
 from scrapli.exceptions import ConnectionNotOpened, ScrapliTimeout
 
@@ -19,27 +19,27 @@ class SlowClass(ScrapeBase):
         self.session_lock = Lock()
         self.session_lock.acquire()
 
-    @operation_timeout("timeout_test")
+    @OperationTimeout("timeout_test")
     def slow_function(self):
         time.sleep(1)
 
-    @operation_timeout("timeout_test")
+    @OperationTimeout("timeout_test")
     def fast_function(self):
         return "fast"
 
-    @operation_timeout("non_existent_class_attr")
+    @OperationTimeout("non_existent_class_attr")
     def confused_function(self):
         return "fast"
 
-    @async_operation_timeout("timeout_test")
+    @OperationTimeout("timeout_test")
     async def async_slow_function(self):
         await asyncio.sleep(1)
 
-    @async_operation_timeout("timeout_test")
+    @OperationTimeout("timeout_test")
     async def async_fast_function(self):
         return "fast"
 
-    @async_operation_timeout("non_existent_class_attr")
+    @OperationTimeout("non_existent_class_attr")
     async def async_confused_function(self):
         return "fast"
 

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -120,7 +120,7 @@ def test_factory_community_platform_defaults(factory_setup):
     Factory = factory_setup[0]
     transport = factory_setup[1]
     expected_driver = factory_setup[2]
-    driver = Factory(platform="scrapli_example", host="localhost", transport=transport)
+    driver = Factory(platform="scrapli_networkdriver", host="localhost", transport=transport)
     assert isinstance(driver, expected_driver)
     assert driver._transport == transport
     assert driver.failed_when_contains == [
@@ -151,7 +151,10 @@ def test_sync_factory_community_platform_variant(factory_setup):
     transport = factory_setup[1]
     expected_driver = factory_setup[2]
     driver = Factory(
-        platform="scrapli_example", host="localhost", variant="test_variant1", transport=transport
+        platform="scrapli_networkdriver",
+        host="localhost",
+        variant="test_variant1",
+        transport=transport,
     )
     assert isinstance(driver, expected_driver)
     assert driver._transport == transport

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -21,6 +21,12 @@ def test_sync_factory(platform):
     assert isinstance(driver, platform[1])
 
 
+def test_sync_factory_async_transport_exception():
+    with pytest.raises(ScrapliException) as exc:
+        Scrapli(transport="asyncssh")
+    assert str(exc.value) == "Use `AsyncScrapli` if using an async transport!"
+
+
 def test_sync_factory_community_driver_exception():
     with pytest.raises(ScrapliException) as exc:
         Scrapli(platform="tacocat")

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -1,0 +1,27 @@
+import pytest
+
+from scrapli.driver.core import EOSDriver, IOSXEDriver, IOSXRDriver, JunosDriver, NXOSDriver
+from scrapli.exceptions import ScrapliException
+from scrapli.factory import Scrapli
+
+
+@pytest.mark.parametrize(
+    "platform",
+    [
+        ("cisco_iosxe", IOSXEDriver),
+        ("cisco_iosxr", IOSXRDriver),
+        ("cisco_nxos", NXOSDriver),
+        ("arista_eos", EOSDriver),
+        ("juniper_junos", JunosDriver),
+    ],
+    ids=["cisco_iosxe", "cisco_iosxr", "cisco_nxos", "arista_eos", "juniper_junos"],
+)
+def test_sync_factory(platform):
+    driver = Scrapli(platform=platform[0], host="localhost")
+    assert isinstance(driver, platform[1])
+
+
+def test_sync_factory_community_driver_exception():
+    with pytest.raises(ScrapliException) as exc:
+        Scrapli(platform="tacocat")
+    assert str(exc.value) == "Community platform support/factory coming soon!"

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -1,8 +1,57 @@
 import pytest
 
-from scrapli.driver.core import EOSDriver, IOSXEDriver, IOSXRDriver, JunosDriver, NXOSDriver
+from scrapli.driver import AsyncNetworkDriver, NetworkDriver
+from scrapli.driver.base_network_driver import PrivilegeLevel
+from scrapli.driver.core import (
+    AsyncEOSDriver,
+    AsyncIOSXEDriver,
+    AsyncIOSXRDriver,
+    AsyncJunosDriver,
+    AsyncNXOSDriver,
+    EOSDriver,
+    IOSXEDriver,
+    IOSXRDriver,
+    JunosDriver,
+    NXOSDriver,
+)
 from scrapli.exceptions import ScrapliException
-from scrapli.factory import Scrapli, _get_core_driver
+from scrapli.factory import AsyncScrapli, Scrapli
+
+TEST_COMMUNITY_PRIV_LEVELS = {
+    "exec": (
+        PrivilegeLevel(
+            pattern=r"^[a-z0-9.\-_@()/:]{1,63}>$",
+            name="exec",
+            previous_priv="",
+            deescalate="",
+            escalate="",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "privilege_exec": (
+        PrivilegeLevel(
+            pattern=r"^[a-z0-9.\-_@/:]{1,63}#$",
+            name="privilege_exec",
+            previous_priv="exec",
+            deescalate="disable",
+            escalate="enable",
+            escalate_auth=True,
+            escalate_prompt=r"^[pP]assword:\s?$",
+        )
+    ),
+    "configuration": (
+        PrivilegeLevel(
+            pattern=r"^[a-z0-9.\-_@/:]{1,63}\(conf[a-z0-9.\-@/:\+]{0,32}\)#$",
+            name="configuration",
+            previous_priv="privilege_exec",
+            deescalate="end",
+            escalate="configure terminal",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+}
 
 
 @pytest.mark.parametrize(
@@ -21,34 +70,104 @@ def test_sync_factory(platform):
     assert isinstance(driver, platform[1])
 
 
+@pytest.mark.parametrize(
+    "platform",
+    [
+        ("cisco_iosxe", AsyncIOSXEDriver),
+        ("cisco_iosxr", AsyncIOSXRDriver),
+        ("cisco_nxos", AsyncNXOSDriver),
+        ("arista_eos", AsyncEOSDriver),
+        ("juniper_junos", AsyncJunosDriver),
+    ],
+    ids=["cisco_iosxe", "cisco_iosxr", "cisco_nxos", "arista_eos", "juniper_junos"],
+)
+def test_async_factory(platform):
+    driver = AsyncScrapli(platform=platform[0], host="localhost", transport="asyncssh")
+    assert isinstance(driver, platform[1])
+
+
 def test_sync_factory_async_transport_exception():
     with pytest.raises(ScrapliException) as exc:
-        Scrapli(transport="asyncssh")
+        Scrapli(platform="cisco_iosxe", transport="asyncssh")
     assert str(exc.value) == "Use `AsyncScrapli` if using an async transport!"
 
 
-def test_sync_factory_community_driver_exception():
+def test_async_factory_sync_transport_exception():
     with pytest.raises(ScrapliException) as exc:
-        Scrapli(platform="tacocat")
-    assert str(exc.value) == "Community platform support/factory coming soon!"
+        AsyncScrapli(platform="cisco_iosxe", transport="system")
+    assert str(exc.value) == "Use `Scrapli` if using a synchronous transport!"
 
 
-def test_sync_factory_no_platform_argument():
+@pytest.mark.parametrize(
+    "factory_setup",
+    [(Scrapli, "system"), (AsyncScrapli, "asyncssh")],
+    ids=["sync_factory", "async_factory"],
+)
+def test_factory_platform_bad_type(factory_setup):
+    Factory = factory_setup[0]
+    transport = factory_setup[1]
     with pytest.raises(ScrapliException) as exc:
-        Scrapli()
-    assert str(exc.value) == "Argument `platform` must be provided when using `Scrapli` factory!"
-
-
-def test_sync_factory_platform_bad_type():
-    with pytest.raises(ScrapliException) as exc:
-        Scrapli(platform=True)
+        Factory(platform=True, transport=transport)
     assert str(exc.value) == "Argument `platform` must be `str` got `<class 'bool'>`"
 
 
-def test_get_core_driver_failure():
-    with pytest.raises(ScrapliException) as exc:
-        _get_core_driver(driver="tacocat")
-    assert (
-        str(exc.value)
-        == "Error importing core driver `tacocat`; exception: `module 'scrapli.driver.core' has no attribute 'tacocat'`"
+@pytest.mark.parametrize(
+    "factory_setup",
+    [(Scrapli, "system", NetworkDriver), (AsyncScrapli, "asyncssh", AsyncNetworkDriver)],
+    ids=["sync_factory", "async_factory"],
+)
+def test_factory_community_platform_defaults(factory_setup):
+    Factory = factory_setup[0]
+    transport = factory_setup[1]
+    expected_driver = factory_setup[2]
+    driver = Factory(platform="scrapli_example", host="localhost", transport=transport)
+    assert isinstance(driver, expected_driver)
+    assert driver._transport == transport
+    assert driver.failed_when_contains == [
+        "% Ambiguous command",
+        "% Incomplete command",
+        "% Invalid input detected",
+        "% Unknown command",
+    ]
+    assert driver.textfsm_platform == "cisco_iosxe"
+    assert driver.genie_platform == "iosxe"
+    assert driver.default_desired_privilege_level == "privilege_exec"
+    assert callable(driver.on_open)
+    assert callable(driver.on_close)
+    for actual_priv_level, expected_priv_level in zip(
+        driver.privilege_levels.values(), TEST_COMMUNITY_PRIV_LEVELS.values()
+    ):
+        actual_priv_level.name == expected_priv_level.name
+        actual_priv_level.pattern == expected_priv_level.pattern
+
+
+@pytest.mark.parametrize(
+    "factory_setup",
+    [(Scrapli, "system", NetworkDriver), (AsyncScrapli, "asyncssh", AsyncNetworkDriver)],
+    ids=["sync_factory", "async_factory"],
+)
+def test_sync_factory_community_platform_variant(factory_setup):
+    Factory = factory_setup[0]
+    transport = factory_setup[1]
+    expected_driver = factory_setup[2]
+    driver = Factory(
+        platform="scrapli_example", host="localhost", variant="test_variant1", transport=transport
     )
+    assert isinstance(driver, expected_driver)
+    assert driver._transport == transport
+    assert driver.failed_when_contains == [
+        "% Ambiguous command",
+        "% Incomplete command",
+        "% Invalid input detected",
+        "% Unknown command",
+    ]
+    assert driver.textfsm_platform == "cisco_iosxe"
+    assert driver.genie_platform == "iosxe"
+    assert driver.default_desired_privilege_level == "configuration"
+    assert callable(driver.on_open)
+    assert callable(driver.on_close)
+    for actual_priv_level, expected_priv_level in zip(
+        driver.privilege_levels.values(), TEST_COMMUNITY_PRIV_LEVELS.values()
+    ):
+        actual_priv_level.name == expected_priv_level.name
+        actual_priv_level.pattern == expected_priv_level.pattern

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -2,7 +2,7 @@ import pytest
 
 from scrapli.driver.core import EOSDriver, IOSXEDriver, IOSXRDriver, JunosDriver, NXOSDriver
 from scrapli.exceptions import ScrapliException
-from scrapli.factory import Scrapli
+from scrapli.factory import Scrapli, _get_core_driver
 
 
 @pytest.mark.parametrize(
@@ -25,3 +25,24 @@ def test_sync_factory_community_driver_exception():
     with pytest.raises(ScrapliException) as exc:
         Scrapli(platform="tacocat")
     assert str(exc.value) == "Community platform support/factory coming soon!"
+
+
+def test_sync_factory_no_platform_argument():
+    with pytest.raises(ScrapliException) as exc:
+        Scrapli()
+    assert str(exc.value) == "Argument `platform` must be provided when using `Scrapli` factory!"
+
+
+def test_sync_factory_platform_bad_type():
+    with pytest.raises(ScrapliException) as exc:
+        Scrapli(platform=True)
+    assert str(exc.value) == "Argument `platform` must be `str` got `<class 'bool'>`"
+
+
+def test_get_core_driver_failure():
+    with pytest.raises(ScrapliException) as exc:
+        _get_core_driver(driver="tacocat")
+    assert (
+        str(exc.value)
+        == "Error importing core driver `tacocat`; exception: `module 'scrapli.driver.core' has no attribute 'tacocat'`"
+    )

--- a/tests/unit/transport/test_systemssh.py
+++ b/tests/unit/transport/test_systemssh.py
@@ -104,8 +104,8 @@ def test_build_open_cmd_user_options(user_options):
             "No matching cipher found for host localhost, their offer: aes128-cbc,aes256-cbc",
         ),
         (
-                b"command-line: line 0: Bad configuration option: ciphers+",
-                "Bad SSH configuration option(s) for host localhost, bad option(s): ciphers+",
+            b"command-line: line 0: Bad configuration option: ciphers+",
+            "Bad SSH configuration option(s) for host localhost, bad option(s): ciphers+",
         ),
         (
             b"WARNING: UNPROTECTED PRIVATE KEY FILE!",

--- a/tests/unit/transport/test_systemssh.py
+++ b/tests/unit/transport/test_systemssh.py
@@ -104,6 +104,10 @@ def test_build_open_cmd_user_options(user_options):
             "No matching cipher found for host localhost, their offer: aes128-cbc,aes256-cbc",
         ),
         (
+                b"command-line: line 0: Bad configuration option: ciphers+",
+                "Bad SSH configuration option(s) for host localhost, bad option(s): ciphers+",
+        ),
+        (
             b"WARNING: UNPROTECTED PRIVATE KEY FILE!",
             # note: empty quotes in the middle is where private key filename would be
             "Permissions for private key `` are too open, authentication failed!",
@@ -123,6 +127,7 @@ def test_build_open_cmd_user_options(user_options):
         "no matching key exchange found key exchange",
         "no matching cipher",
         "no matching cipher found ciphers",
+        "bad configuration option",
         "unprotected key",
         "could not resolve host",
     ],


### PR DESCRIPTION
- Fixed the same `get_prompt` issue from the last release, but this time managed to actually fix it in async version!
- Better handling of `read_until_input` -- stripping some characters out that may get inserted (backspace char), and compares a normalized whitespace version of the read output to the a normalized whitespace version of the input, fixes [#36](https://github.com/carlmontanari/scrapli/issues/36).
- Improved system transport ssh error handling -- catch cipher/kex errors better, catch bad configuration messages.
- Now raise an exception if trying to use an invalid transport class for the base driver type -- i.e. if using asyncssh transport plugin with the "normal" sync driver class.
- Added links to the other projects in the scrapli "family" to the readme.
- Created first draft of the scrapli "factory" -- this will allow users to provide the platform name as a string to a single `Scrapli` or `AsyncScrapli` class and it will automagically get the right platform driver selected and such. This is also the first support for `scrapli_community`, which will allow users to contribute non "core" platforms and have them be usable in scrapli just like "normal".
- Overhaul decorators for timeouts into a single class (for sync and async), prefer to use signals timeout method where possible, fall back to multiprocessing timeout where required (multiprocessing is slower/more cpu intensive so dont use it if we dont have to).
