### PR TITLE
Update regular expressions for IOS-XE prompts

### DIFF
--- a/scrapli/driver/core/cisco_iosxe/base_driver.py
+++ b/scrapli/driver/core/cisco_iosxe/base_driver.py
@@ -4,7 +4,7 @@ from scrapli.driver.network.base_driver import PrivilegeLevel
 PRIVS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^((?!tcl)[a-z0-9.\-_@()/:]){1,63}>$",
+            pattern=r"^(?!tcl)[\w.\-@/:]+>$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -15,7 +15,7 @@ PRIVS = {
     ),
     "privilege_exec": (
         PrivilegeLevel(
-            pattern=r"^((?!tcl)[a-z0-9.\-_@/:]){1,63}#$",
+            pattern=r"^(?!tcl)[\w.\-@/:]+#$",
             name="privilege_exec",
             previous_priv="exec",
             deescalate="disable",
@@ -26,7 +26,7 @@ PRIVS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^[a-z0-9.\-_@/:]{1,63}\((?!tcl)[a-z0-9.\-@/:\+]{0,32}\)#$",
+            pattern=r"^[\w.\-@/:]+\((?!tcl)[\w.\-@/:+]{0,32}\)#$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="end",
@@ -37,7 +37,7 @@ PRIVS = {
     ),
     "tclsh": (
         PrivilegeLevel(
-            pattern=r"(^[a-z0-9.\-_@/:]{1,63}\(tcl\)[>#]$)|(^\+>$)",
+            pattern=r"^([\w.\-@/+>:]+\(tcl\)[>#]|\+>)$",
             name="tclsh",
             previous_priv="privilege_exec",
             deescalate="tclquit",

--- a/tests/unit/driver/core/cisco_iosxe/test_base_driver.py
+++ b/tests/unit/driver/core/cisco_iosxe/test_base_driver.py
@@ -17,6 +17,7 @@ from scrapli.driver.core.cisco_iosxe.base_driver import PRIVS
         ("configuration", "819HGW(ipsec-profile)#"),
         ("tclsh", "819HGW(tcl)#"),
         ("tclsh", "+>"),
+        ("tclsh", "+>(tcl)#"),
     ],
     ids=[
         "base_prompt_exec",
@@ -28,6 +29,7 @@ from scrapli.driver.core.cisco_iosxe.base_driver import PRIVS
         "ipsec_profile",
         "tclsh",
         "tclsh_command_mode",
+        "tclsh_command_mode_17+",
     ],
 )
 def test_prompt_patterns(priv_pattern):


### PR DESCRIPTION
# Description

Updated regular expressions for IOS-XE prompts/privilege levels.
Motivation:
1) Fix #97
2) Simplified some patterns (e.g. `[a-z0-9_]` -> `\w`)
3) IOS-XE hostname now supports more than 63 symbols (though only 99 are displayed at maximum), probably doesn't make sense to hardcode, replaced with `+`

Note: I have some concerns regarding negative lookahead, e.g. `^(?!tcl)[\w.\-@/:]+>$` - I am not sure it is doing what it is supposed to be doing.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test


# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
