### PR TITLE
Fix for EOS config prompts with mixed case, special characters, and really long lines

### DIFF
--- a/scrapli/driver/core/arista_eos/base_driver.py
+++ b/scrapli/driver/core/arista_eos/base_driver.py
@@ -35,7 +35,7 @@ PRIVS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^[a-z0-9.\-@()/: ]{1,63}\(config(?!\-s\-)[a-z0-9_.\-@/:]{0,32}\)#\s?$",
+            pattern=r"^[a-z0-9.\-@()/: ]{1,63}\(config(?!\-s\-)[A-Za-z0-9_.\-@/:+]{0,96}\)#\s?$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="end",

--- a/tests/unit/driver/core/arista_eos/test_arista_eos_base_driver.py
+++ b/tests/unit/driver/core/arista_eos/test_arista_eos_base_driver.py
@@ -18,6 +18,10 @@ from scrapli.exceptions import ScrapliValueError
         ("exec", "localhost(some thing)>"),
         ("privilege_exec", "localhost(some thing)#"),
         ("configuration", "localhost(some thing)(config)#"),
+        (
+            "configuration",
+            "localhost(config-sg-tacacs+-Yes-EOS_Allows_This_1-Silly_Is_It_Not-And_Yes_It_Can_Be_This_Long)#",
+        ),
     ],
     ids=[
         "exec",
@@ -29,6 +33,7 @@ from scrapli.exceptions import ScrapliValueError
         "exec_with_space",
         "privilege_exec_with_space",
         "config_with_space",
+        "config_mixed_case_special_chars_very_long",
     ],
 )
 def test_prompt_patterns(priv_pattern):


### PR DESCRIPTION
# Description

Fix as suggested here:

[https://github.com/carlmontanari/scrapli/discussions/123](https://github.com/carlmontanari/scrapli/discussions/123)

To summarize, EOS can generate some really long prompts that include non-alphanumeric characters and mixed case.  To address this, the regex for matching the config mode prompt was modified.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with the unit tests, but also tested against multiple pieces of Arista gear with various different EOS versions.

# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
