### PR TITLE
Add send commands(ignore privelege level)

### DIFF
--- a/scrapli/driver/network/async_driver.py
+++ b/scrapli/driver/network/async_driver.py
@@ -193,8 +193,9 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if self._current_priv_level.name != self.default_desired_privilege_level:
-            await self.acquire_priv(desired_priv=self.default_desired_privilege_level)
+        if not ignore_privilege_level:
+            if self._current_priv_level.name != self.default_desired_privilege_level:
+                await self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains
@@ -247,8 +248,9 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if self._current_priv_level.name != self.default_desired_privilege_level:
-            await self.acquire_priv(desired_priv=self.default_desired_privilege_level)
+        if not ignore_privilege_level:
+            if self._current_priv_level.name != self.default_desired_privilege_level:
+                await self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains
@@ -303,8 +305,9 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if self._current_priv_level.name != self.default_desired_privilege_level:
-            await self.acquire_priv(desired_priv=self.default_desired_privilege_level)
+        if not ignore_privilege_level:
+            if self._current_priv_level.name != self.default_desired_privilege_level:
+                await self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains

--- a/scrapli/driver/network/async_driver.py
+++ b/scrapli/driver/network/async_driver.py
@@ -315,13 +315,13 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
         commands = self._pre_send_from_file(file=file, caller="send_commands_from_file")
 
         return await self.send_commands(
-                commands=commands,
-                strip_prompt=strip_prompt,
-                failed_when_contains=failed_when_contains,
-                stop_on_failed=stop_on_failed,
-                eager=eager,
-                timeout_ops=timeout_ops,
-                ignore_privilege_level=ignore_privilege_level,
+            commands=commands,
+            strip_prompt=strip_prompt,
+            failed_when_contains=failed_when_contains,
+            stop_on_failed=stop_on_failed,
+            eager=eager,
+            timeout_ops=timeout_ops,
+            ignore_privilege_level=ignore_privilege_level,
         )
 
     async def send_interactive(

--- a/scrapli/driver/network/async_driver.py
+++ b/scrapli/driver/network/async_driver.py
@@ -397,8 +397,9 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
         else:
             resolved_privilege_level = self.default_desired_privilege_level
 
-        if self._current_priv_level.name != resolved_privilege_level:
-            await self.acquire_priv(desired_priv=resolved_privilege_level)
+        if not self.ignore_privilege_level:
+            if self._current_priv_level.name != resolved_privilege_level:
+                await self.acquire_priv(desired_priv=resolved_privilege_level)
 
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains

--- a/scrapli/driver/network/async_driver.py
+++ b/scrapli/driver/network/async_driver.py
@@ -10,6 +10,9 @@ from scrapli.response import MultiResponse, Response
 
 
 class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
+    # True will only use default_desired_privilege_level
+    ignore_privilege_level = False
+
     def __init__(
         self,
         host: str,
@@ -169,7 +172,6 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
         strip_prompt: bool = True,
         failed_when_contains: Optional[Union[str, List[str]]] = None,
         timeout_ops: Optional[float] = None,
-        ignore_privilege_level: bool = False,
     ) -> Response:
         """
         Send a command
@@ -183,8 +185,6 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
             timeout_ops: timeout ops value for this operation; only sets the timeout_ops value for
                 the duration of the operation, value is reset to initial value after operation is
                 completed
-            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
-                specific privilege level. The current privilege level will be used.
 
         Returns:
             Response: Scrapli Response object
@@ -193,7 +193,7 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if not ignore_privilege_level:
+        if not self.ignore_privilege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
                 await self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
@@ -219,7 +219,6 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
-        ignore_privilege_level: bool = False,
     ) -> MultiResponse:
         """
         Send multiple commands
@@ -239,8 +238,6 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
                 the duration of the operation, value is reset to initial value after operation is
                 completed. Note that this is the timeout value PER COMMAND sent, not for the total
                 of the commands being sent!
-            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
-                specific privilege level. The current privilege level will be used.
         Returns:
             MultiResponse: Scrapli MultiResponse object
 
@@ -248,7 +245,7 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if not ignore_privilege_level:
+        if not self.ignore_privilege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
                 await self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
@@ -278,7 +275,6 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
-        ignore_privilege_level: bool = False,
     ) -> MultiResponse:
         """
         Send command(s) from file
@@ -296,8 +292,6 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
                 the duration of the operation, value is reset to initial value after operation is
                 completed. Note that this is the timeout value PER COMMAND sent, not for the total
                 of the commands being sent!
-            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
-                specific privilege level. The current privilege level will be used.
         Returns:
             MultiResponse: Scrapli MultiResponse object
 
@@ -305,7 +299,7 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if not ignore_privilege_level:
+        if not self.ignore_privilege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
                 await self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
@@ -321,7 +315,6 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
             stop_on_failed=stop_on_failed,
             eager=eager,
             timeout_ops=timeout_ops,
-            ignore_privilege_level=ignore_privilege_level,
         )
 
     async def send_interactive(

--- a/scrapli/driver/network/async_driver.py
+++ b/scrapli/driver/network/async_driver.py
@@ -169,6 +169,7 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
         strip_prompt: bool = True,
         failed_when_contains: Optional[Union[str, List[str]]] = None,
         timeout_ops: Optional[float] = None,
+        ignore_privilege_level: bool = False,
     ) -> Response:
         """
         Send a command
@@ -182,6 +183,8 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
             timeout_ops: timeout ops value for this operation; only sets the timeout_ops value for
                 the duration of the operation, value is reset to initial value after operation is
                 completed
+            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
+                specific privilege level. The current privilege level will be used.
 
         Returns:
             Response: Scrapli Response object
@@ -215,6 +218,7 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
+        ignore_privilege_level: bool = False,
     ) -> MultiResponse:
         """
         Send multiple commands
@@ -234,7 +238,8 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
                 the duration of the operation, value is reset to initial value after operation is
                 completed. Note that this is the timeout value PER COMMAND sent, not for the total
                 of the commands being sent!
-
+            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
+                specific privilege level. The current privilege level will be used.
         Returns:
             MultiResponse: Scrapli MultiResponse object
 
@@ -271,6 +276,7 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
+        ignore_privilege_level: bool = False,
     ) -> MultiResponse:
         """
         Send command(s) from file
@@ -288,7 +294,8 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
                 the duration of the operation, value is reset to initial value after operation is
                 completed. Note that this is the timeout value PER COMMAND sent, not for the total
                 of the commands being sent!
-
+            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
+                specific privilege level. The current privilege level will be used.
         Returns:
             MultiResponse: Scrapli MultiResponse object
 

--- a/scrapli/driver/network/async_driver.py
+++ b/scrapli/driver/network/async_driver.py
@@ -477,9 +477,9 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
             failed_when_contains=failed_when_contains,
             privilege_level=privilege_level,
         )
-
-        if self._current_priv_level.name != resolved_privilege_level:
-            await self.acquire_priv(desired_priv=resolved_privilege_level)
+        if not self.ignore_privilege_level:
+            if self._current_priv_level.name != resolved_privilege_level:
+                await self.acquire_priv(desired_priv=resolved_privilege_level)
 
         responses = await super().send_commands(
             commands=configs,

--- a/scrapli/driver/network/async_driver.py
+++ b/scrapli/driver/network/async_driver.py
@@ -312,13 +312,16 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains
 
-        return await super().send_commands_from_file(
-            file=file,
-            strip_prompt=strip_prompt,
-            failed_when_contains=failed_when_contains,
-            stop_on_failed=stop_on_failed,
-            eager=eager,
-            timeout_ops=timeout_ops,
+        commands = self._pre_send_from_file(file=file, caller="send_commands_from_file")
+
+        return await self.send_commands(
+                commands=commands,
+                strip_prompt=strip_prompt,
+                failed_when_contains=failed_when_contains,
+                stop_on_failed=stop_on_failed,
+                eager=eager,
+                timeout_ops=timeout_ops,
+                ignore_privilege_level=ignore_privilege_level,
         )
 
     async def send_interactive(

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -399,8 +399,9 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         else:
             resolved_privilege_level = self.default_desired_privilege_level
 
-        if self._current_priv_level.name != resolved_privilege_level:
-            self.acquire_priv(desired_priv=resolved_privilege_level)
+        if not self.ignore_privilege_level:
+            if self._current_priv_level.name != resolved_privilege_level:
+                self.acquire_priv(desired_priv=resolved_privilege_level)
 
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -215,6 +215,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
+        ignore_privelege_level: bool = False
     ) -> MultiResponse:
         """
         Send multiple commands
@@ -242,8 +243,10 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if self._current_priv_level.name != self.default_desired_privilege_level:
-            self.acquire_priv(desired_priv=self.default_desired_privilege_level)
+
+        if ignore_privelege_level:
+            if self._current_priv_level.name != self.default_desired_privilege_level:
+                self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -10,6 +10,9 @@ from scrapli.response import MultiResponse, Response
 
 
 class NetworkDriver(GenericDriver, BaseNetworkDriver):
+    # True will only use default_desired_privilege_level
+    ignore_privilege_level = False
+
     def __init__(
         self,
         host: str,
@@ -169,7 +172,6 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         strip_prompt: bool = True,
         failed_when_contains: Optional[Union[str, List[str]]] = None,
         timeout_ops: Optional[float] = None,
-        ignore_privilege_level: bool = False,
     ) -> Response:
         """
         Send a command
@@ -183,8 +185,6 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             timeout_ops: timeout ops value for this operation; only sets the timeout_ops value for
                 the duration of the operation, value is reset to initial value after operation is
                 completed
-            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
-                specific privilege level. The current privilege level will be used.
         Returns:
             Response: Scrapli Response object
 
@@ -192,7 +192,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if not ignore_privilege_level:
+        if not self.ignore_privilege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
                 self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
@@ -218,7 +218,6 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
-        ignore_privilege_level: bool = False,
     ) -> MultiResponse:
         """
         Send multiple commands
@@ -238,8 +237,6 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
                 the duration of the operation, value is reset to initial value after operation is
                 completed. Note that this is the timeout value PER COMMAND sent, not for the total
                 of the commands being sent!
-            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
-                specific privilege level. The current privilege level will be used.
 
         Returns:
             MultiResponse: Scrapli MultiResponse object
@@ -249,7 +246,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
 
         """
 
-        if not ignore_privilege_level:
+        if not self.ignore_privilege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
                 self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
@@ -279,7 +276,6 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
-        ignore_privilege_level: bool = False,
     ) -> MultiResponse:
         """
         Send command(s) from file
@@ -297,8 +293,6 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
                 the duration of the operation, value is reset to initial value after operation is
                 completed. Note that this is the timeout value PER COMMAND sent, not for the total
                 of the commands being sent!
-            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
-                specific privilege level. The current privilege level will be used.
 
         Returns:
             MultiResponse: Scrapli MultiResponse object
@@ -307,7 +301,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if not ignore_privilege_level:
+        if not self.ignore_privilege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
                 self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
@@ -323,7 +317,6 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             stop_on_failed=stop_on_failed,
             eager=eager,
             timeout_ops=timeout_ops,
-            ignore_privilege_level=ignore_privilege_level,
         )
 
     def send_interactive(

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -279,6 +279,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
+        ignore_privelege_level: bool = False,
     ) -> MultiResponse:
         """
         Send command(s) from file
@@ -296,6 +297,8 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
                 the duration of the operation, value is reset to initial value after operation is
                 completed. Note that this is the timeout value PER COMMAND sent, not for the total
                 of the commands being sent!
+            ignore_privelege_level: if ignore_privelege_level is True we will not acquire any
+            specific privilege level. The current privilege level will be used.
 
         Returns:
             MultiResponse: Scrapli MultiResponse object
@@ -304,8 +307,9 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if self._current_priv_level.name != self.default_desired_privilege_level:
-            self.acquire_priv(desired_priv=self.default_desired_privilege_level)
+        if not ignore_privelege_level:
+            if self._current_priv_level.name != self.default_desired_privilege_level:
+                    self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -317,13 +317,13 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         commands = self._pre_send_from_file(file=file, caller="send_commands_from_file")
 
         return self.send_commands(
-                commands=commands,
-                strip_prompt=strip_prompt,
-                failed_when_contains=failed_when_contains,
-                stop_on_failed=stop_on_failed,
-                eager=eager,
-                timeout_ops=timeout_ops,
-                ignore_privilege_level=ignore_privilege_level,
+            commands=commands,
+            strip_prompt=strip_prompt,
+            failed_when_contains=failed_when_contains,
+            stop_on_failed=stop_on_failed,
+            eager=eager,
+            timeout_ops=timeout_ops,
+            ignore_privilege_level=ignore_privilege_level,
         )
 
     def send_interactive(

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -194,7 +194,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         """
         if not ignore_privelege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
-                    self.acquire_priv(desired_priv=self.default_desired_privilege_level)
+                self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains
@@ -309,7 +309,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         """
         if not ignore_privelege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
-                    self.acquire_priv(desired_priv=self.default_desired_privilege_level)
+                self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -314,13 +314,16 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains
 
-        return super().send_commands_from_file(
-            file=file,
-            strip_prompt=strip_prompt,
-            failed_when_contains=failed_when_contains,
-            stop_on_failed=stop_on_failed,
-            eager=eager,
-            timeout_ops=timeout_ops,
+        commands = self._pre_send_from_file(file=file, caller="send_commands_from_file")
+
+        return self.send_commands(
+                commands=commands,
+                strip_prompt=strip_prompt,
+                failed_when_contains=failed_when_contains,
+                stop_on_failed=stop_on_failed,
+                eager=eager,
+                timeout_ops=timeout_ops,
+                ignore_privilege_level=ignore_privilege_level,
         )
 
     def send_interactive(

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -480,8 +480,9 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             privilege_level=privilege_level,
         )
 
-        if self._current_priv_level.name != resolved_privilege_level:
-            self.acquire_priv(desired_priv=resolved_privilege_level)
+        if not self.ignore_privilege_level:
+            if self._current_priv_level.name != resolved_privilege_level:
+                self.acquire_priv(desired_priv=resolved_privilege_level)
 
         responses = super().send_commands(
             commands=configs,

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -169,7 +169,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         strip_prompt: bool = True,
         failed_when_contains: Optional[Union[str, List[str]]] = None,
         timeout_ops: Optional[float] = None,
-        ignore_privelege_level: bool = False,
+        ignore_privilege_level: bool = False,
     ) -> Response:
         """
         Send a command
@@ -183,8 +183,8 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             timeout_ops: timeout ops value for this operation; only sets the timeout_ops value for
                 the duration of the operation, value is reset to initial value after operation is
                 completed
-            ignore_privelege_level: if ignore_privelege_level is True we will not acquire any
-            specific privilege level. The current privilege level will be used.
+            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
+                specific privilege level. The current privilege level will be used.
         Returns:
             Response: Scrapli Response object
 
@@ -192,7 +192,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if not ignore_privelege_level:
+        if not ignore_privilege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
                 self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
@@ -218,7 +218,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
-        ignore_privelege_level: bool = False,
+        ignore_privilege_level: bool = False,
     ) -> MultiResponse:
         """
         Send multiple commands
@@ -238,8 +238,8 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
                 the duration of the operation, value is reset to initial value after operation is
                 completed. Note that this is the timeout value PER COMMAND sent, not for the total
                 of the commands being sent!
-            ignore_privelege_level: if ignore_privelege_level is True we will not acquire any
-            specific privilege level. The current privilege level will be used.
+            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
+                specific privilege level. The current privilege level will be used.
 
         Returns:
             MultiResponse: Scrapli MultiResponse object
@@ -249,7 +249,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
 
         """
 
-        if not ignore_privelege_level:
+        if not ignore_privilege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
                 self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
@@ -279,7 +279,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
-        ignore_privelege_level: bool = False,
+        ignore_privilege_level: bool = False,
     ) -> MultiResponse:
         """
         Send command(s) from file
@@ -297,8 +297,8 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
                 the duration of the operation, value is reset to initial value after operation is
                 completed. Note that this is the timeout value PER COMMAND sent, not for the total
                 of the commands being sent!
-            ignore_privelege_level: if ignore_privelege_level is True we will not acquire any
-            specific privilege level. The current privilege level will be used.
+            ignore_privilege_level: if ignore_privilege_level is True we will not acquire any
+                specific privilege level. The current privilege level will be used.
 
         Returns:
             MultiResponse: Scrapli MultiResponse object
@@ -307,7 +307,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if not ignore_privelege_level:
+        if not ignore_privilege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
                 self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -215,7 +215,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         stop_on_failed: bool = False,
         eager: bool = False,
         timeout_ops: Optional[float] = None,
-        ignore_privelege_level: bool = False
+        ignore_privelege_level: bool = False,
     ) -> MultiResponse:
         """
         Send multiple commands
@@ -235,6 +235,8 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
                 the duration of the operation, value is reset to initial value after operation is
                 completed. Note that this is the timeout value PER COMMAND sent, not for the total
                 of the commands being sent!
+            ignore_privelege_level: if ignore_privelege_level is True we will not acquire any
+            specific privilege level. The current privilege level will be used.
 
         Returns:
             MultiResponse: Scrapli MultiResponse object

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -169,6 +169,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
         strip_prompt: bool = True,
         failed_when_contains: Optional[Union[str, List[str]]] = None,
         timeout_ops: Optional[float] = None,
+        ignore_privelege_level: bool = False,
     ) -> Response:
         """
         Send a command
@@ -182,7 +183,8 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             timeout_ops: timeout ops value for this operation; only sets the timeout_ops value for
                 the duration of the operation, value is reset to initial value after operation is
                 completed
-
+            ignore_privelege_level: if ignore_privelege_level is True we will not acquire any
+            specific privilege level. The current privilege level will be used.
         Returns:
             Response: Scrapli Response object
 
@@ -190,8 +192,9 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
             N/A
 
         """
-        if self._current_priv_level.name != self.default_desired_privilege_level:
-            self.acquire_priv(desired_priv=self.default_desired_privilege_level)
+        if not ignore_privelege_level:
+            if self._current_priv_level.name != self.default_desired_privilege_level:
+                    self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 
         if failed_when_contains is None:
             failed_when_contains = self.failed_when_contains
@@ -246,7 +249,7 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
 
         """
 
-        if ignore_privelege_level:
+        if not ignore_privelege_level:
             if self._current_priv_level.name != self.default_desired_privilege_level:
                 self.acquire_priv(desired_priv=self.default_desired_privilege_level)
 

--- a/tests/unit/driver/network/test_network_async_driver.py
+++ b/tests/unit/driver/network/test_network_async_driver.py
@@ -1,10 +1,11 @@
 import sys
+from unittest.mock import patch
 
 import pytest
 
-from unittest.mock import patch
-from scrapli.exceptions import ScrapliPrivilegeError
 from scrapli.driver.network import AsyncNetworkDriver
+from scrapli.exceptions import ScrapliPrivilegeError
+
 
 @pytest.mark.asyncio
 async def test_escalate(monkeypatch, async_network_driver):
@@ -171,7 +172,6 @@ async def test_send_command(monkeypatch, async_network_driver):
 
 @pytest.mark.asyncio
 async def test_send_command_ignore_privilege_level(monkeypatch, async_network_driver):
-
     async def _send_input(cls, channel_input, **kwargs):
         return b"raw", b"processed"
 
@@ -185,7 +185,9 @@ async def test_send_command_ignore_privilege_level(monkeypatch, async_network_dr
     with patch.object(target=AsyncNetworkDriver, attribute="acquire_priv") as mocked_method:
         await async_network_driver.send_command(command="show version", ignore_privilege_level=True)
         mocked_method.assert_not_called()
-        await async_network_driver.send_command(command="show version", ignore_privilege_level=False)
+        await async_network_driver.send_command(
+            command="show version", ignore_privilege_level=False
+        )
         mocked_method.assert_called()
 
 
@@ -241,9 +243,13 @@ async def test_send_commands_ignore_privilege_level(monkeypatch, async_network_d
     ]
     async_network_driver.default_desired_privilege_level = "exec"
     with patch.object(target=AsyncNetworkDriver, attribute="acquire_priv") as mocked_method:
-        await async_network_driver.send_commands(commands=["show version", "show run"], ignore_privilege_level=True)
+        await async_network_driver.send_commands(
+            commands=["show version", "show run"], ignore_privilege_level=True
+        )
         mocked_method.assert_not_called()
-        await async_network_driver.send_commands(commands=["show version", "show run"], ignore_privilege_level=False)
+        await async_network_driver.send_commands(
+            commands=["show version", "show run"], ignore_privilege_level=False
+        )
         mocked_method.assert_called()
 
 
@@ -283,7 +289,7 @@ async def test_send_commands_from_file(
 @pytest.mark.asyncio
 @pytest.mark.skipif(sys.version_info >= (3, 10), reason="skipping pending pyfakefs 3.10 support")
 async def test_send_commands_from_file_ignore_privilege_level(
-        fs, monkeypatch, real_ssh_commands_file_path, async_network_driver
+    fs, monkeypatch, real_ssh_commands_file_path, async_network_driver
 ):
     fs.add_real_file(source_path=real_ssh_commands_file_path, target_path="/commands")
 
@@ -297,9 +303,13 @@ async def test_send_commands_from_file_ignore_privilege_level(
     ]
     async_network_driver.default_desired_privilege_level = "exec"
     with patch.object(target=AsyncNetworkDriver, attribute="acquire_priv") as mocked_method:
-        await async_network_driver.send_commands_from_file(file="commands", ignore_privilege_level=True)
+        await async_network_driver.send_commands_from_file(
+            file="commands", ignore_privilege_level=True
+        )
         mocked_method.assert_not_called()
-        await async_network_driver.send_commands_from_file(file="commands", ignore_privilege_level=False)
+        await async_network_driver.send_commands_from_file(
+            file="commands", ignore_privilege_level=False
+        )
         mocked_method.assert_called()
 
 

--- a/tests/unit/driver/network/test_network_async_driver.py
+++ b/tests/unit/driver/network/test_network_async_driver.py
@@ -182,11 +182,11 @@ async def test_send_command_ignore_privilege_level(monkeypatch, async_network_dr
     # patching acquire priv so we know its called but dont have to worry about that actually
     # trying to happen
     monkeypatch.setattr(
-            "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
+        "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
     )
 
     async def _send_input(cls, channel_input, **kwargs):
-            return b"raw", b"processed"
+        return b"raw", b"processed"
 
     monkeypatch.setattr("scrapli.channel.async_channel.AsyncChannel.send_input", _send_input)
 
@@ -202,9 +202,7 @@ async def test_send_command_ignore_privilege_level(monkeypatch, async_network_dr
     _acquire_priv_called = False
 
     async_network_driver.ignore_privilege_level = True
-    await async_network_driver.send_command(
-        command="show version"
-    )
+    await async_network_driver.send_command(command="show version")
     assert not _acquire_priv_called
 
 
@@ -257,8 +255,9 @@ async def test_send_commands_ignore_privilege_level(monkeypatch, async_network_d
 
         # patching acquire priv so we know its called but dont have to worry about that actually
         # trying to happen
+
     monkeypatch.setattr(
-            "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
+        "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
     )
 
     _command_counter = 0
@@ -274,18 +273,13 @@ async def test_send_commands_ignore_privilege_level(monkeypatch, async_network_d
     async_network_driver.default_desired_privilege_level = "exec"
 
     async_network_driver.ignore_privilege_level = False
-    await async_network_driver.send_commands(
-        commands=["show version", "show run"]
-    )
+    await async_network_driver.send_commands(commands=["show version", "show run"])
     assert _acquire_priv_called
     _acquire_priv_called = False
 
     async_network_driver.ignore_privilege_level = True
-    await async_network_driver.send_commands(
-        commands=["show version", "show run"]
-    )
+    await async_network_driver.send_commands(commands=["show version", "show run"])
     assert not _acquire_priv_called
-
 
 
 @pytest.mark.asyncio
@@ -335,8 +329,9 @@ async def test_send_commands_from_file_ignore_privilege_level(
 
         # patching acquire priv so we know its called but dont have to worry about that actually
         # trying to happen
+
     monkeypatch.setattr(
-            "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
+        "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
     )
 
     fs.add_real_file(source_path=real_ssh_commands_file_path, target_path="/commands")
@@ -352,16 +347,12 @@ async def test_send_commands_from_file_ignore_privilege_level(
     async_network_driver.default_desired_privilege_level = "exec"
 
     async_network_driver.ignore_privilege_level = False
-    await async_network_driver.send_commands_from_file(
-        file="commands"
-    )
+    await async_network_driver.send_commands_from_file(file="commands")
     assert _acquire_priv_called
     _acquire_priv_called = False
 
     async_network_driver.ignore_privilege_level = True
-    await async_network_driver.send_commands_from_file(
-        file="commands"
-    )
+    await async_network_driver.send_commands_from_file(file="commands")
     assert not _acquire_priv_called
 
 
@@ -408,14 +399,14 @@ async def test_send_interactive_ignore_privilege_level(monkeypatch, async_networ
     # patching acquire priv so we know its called but dont have to worry about that actually
     # trying to happen
     monkeypatch.setattr(
-            "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
+        "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
     )
 
     async def _send_inputs_interact(cls, **kwargs):
         return b"raw", b"processed"
 
     monkeypatch.setattr(
-            "scrapli.channel.async_channel.AsyncChannel.send_inputs_interact", _send_inputs_interact
+        "scrapli.channel.async_channel.AsyncChannel.send_inputs_interact", _send_inputs_interact
     )
 
     async_network_driver._current_priv_level = async_network_driver.privilege_levels[
@@ -424,16 +415,12 @@ async def test_send_interactive_ignore_privilege_level(monkeypatch, async_networ
     async_network_driver.default_desired_privilege_level = "exec"
 
     async_network_driver.ignore_privilege_level = False
-    await async_network_driver.send_interactive(
-            interact_events=[("nada", "scrapli>")]
-    )
+    await async_network_driver.send_interactive(interact_events=[("nada", "scrapli>")])
     assert _acquire_priv_called
     _acquire_priv_called = False
 
     async_network_driver.ignore_privilege_level = True
-    await async_network_driver.send_interactive(
-            interact_events=[("nada", "scrapli>")]
-    )
+    await async_network_driver.send_interactive(interact_events=[("nada", "scrapli>")])
     assert not _acquire_priv_called
 
 
@@ -482,10 +469,11 @@ async def test_send_configs_ignore_privilege_level(monkeypatch, async_network_dr
         nonlocal _acquire_priv_called
         _acquire_priv_called = True
         return
+
     # patching acquire priv so we know its called but dont have to worry about that actually
     # trying to happen
     monkeypatch.setattr(
-            "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
+        "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
     )
 
     _command_counter = 0
@@ -500,14 +488,14 @@ async def test_send_configs_ignore_privilege_level(monkeypatch, async_network_dr
     ]
     async_network_driver.ignore_privilege_level = False
     await async_network_driver.send_configs(
-            configs=["interface loopback123", "description tests are boring"]
+        configs=["interface loopback123", "description tests are boring"]
     )
     assert _acquire_priv_called
     _acquire_priv_called = False
 
     async_network_driver.ignore_privilege_level = True
     await async_network_driver.send_configs(
-            configs=["interface loopback123", "description tests are boring"]
+        configs=["interface loopback123", "description tests are boring"]
     )
     assert not _acquire_priv_called
 

--- a/tests/unit/driver/network/test_network_async_driver.py
+++ b/tests/unit/driver/network/test_network_async_driver.py
@@ -248,6 +248,19 @@ async def test_send_commands(monkeypatch, async_network_driver):
 
 @pytest.mark.asyncio
 async def test_send_commands_ignore_privilege_level(monkeypatch, async_network_driver):
+    _acquire_priv_called = False
+
+    async def _acquire_priv(cls, **kwargs):
+        nonlocal _acquire_priv_called
+        _acquire_priv_called = True
+        return
+
+        # patching acquire priv so we know its called but dont have to worry about that actually
+        # trying to happen
+    monkeypatch.setattr(
+            "scrapli.driver.network.async_driver.AsyncNetworkDriver.acquire_priv", _acquire_priv
+    )
+
     _command_counter = 0
 
     async def _send_input(cls, channel_input, **kwargs):
@@ -259,15 +272,20 @@ async def test_send_commands_ignore_privilege_level(monkeypatch, async_network_d
         "privilege_exec"
     ]
     async_network_driver.default_desired_privilege_level = "exec"
-    with patch.object(target=AsyncNetworkDriver, attribute="acquire_priv") as mocked_method:
-        await async_network_driver.send_commands(
-            commands=["show version", "show run"], ignore_privilege_level=True
-        )
-        mocked_method.assert_not_called()
-        await async_network_driver.send_commands(
-            commands=["show version", "show run"], ignore_privilege_level=False
-        )
-        mocked_method.assert_called()
+
+    async_network_driver.ignore_privilege_level = False
+    await async_network_driver.send_commands(
+        commands=["show version", "show run"]
+    )
+    assert _acquire_priv_called
+    _acquire_priv_called = False
+
+    async_network_driver.ignore_privilege_level = True
+    await async_network_driver.send_commands(
+        commands=["show version", "show run"]
+    )
+    assert not _acquire_priv_called
+
 
 
 @pytest.mark.asyncio

--- a/tests/unit/driver/network/test_network_async_driver.py
+++ b/tests/unit/driver/network/test_network_async_driver.py
@@ -300,7 +300,7 @@ async def test_send_commands_from_file_ignore_privilege_level(
         await async_network_driver.send_commands_from_file(file="commands", ignore_privilege_level=True)
         mocked_method.assert_not_called()
         await async_network_driver.send_commands_from_file(file="commands", ignore_privilege_level=False)
-        mocked_method.assert_not_called()
+        mocked_method.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/driver/network/test_network_sync_driver.py
+++ b/tests/unit/driver/network/test_network_sync_driver.py
@@ -269,9 +269,6 @@ def test_send_commands_from_file_ignore_privilege_level(fs, monkeypatch, real_ss
         mocked_method.assert_called()
 
 
-
-
-
 def test_send_interactive(monkeypatch, sync_network_driver):
     def _acquire_priv(cls, **kwargs):
         return

--- a/tests/unit/driver/network/test_network_sync_driver.py
+++ b/tests/unit/driver/network/test_network_sync_driver.py
@@ -168,7 +168,7 @@ def test_send_command_ignore_privilege_level(monkeypatch, sync_network_driver):
     sync_network_driver._current_priv_level = sync_network_driver.privilege_levels["privilege_exec"]
     sync_network_driver.default_desired_privilege_level = "exec"
 
-    sync_network_driver.ignore_privilege_level= False
+    sync_network_driver.ignore_privilege_level = False
     sync_network_driver.send_command(
         command="show version",
     )

--- a/tests/unit/driver/network/test_network_sync_driver.py
+++ b/tests/unit/driver/network/test_network_sync_driver.py
@@ -6,6 +6,7 @@ import pytest
 from scrapli.driver.network import NetworkDriver
 from scrapli.exceptions import ScrapliPrivilegeError
 
+
 def test_escalate(monkeypatch, sync_network_driver):
     def _send_input(cls, channel_input, **kwargs):
         assert channel_input == "configure terminal"
@@ -157,7 +158,7 @@ def test_send_command_ignore_privilege_level(monkeypatch, sync_network_driver):
     # patching acquire priv so we know its called but dont have to worry about that actually
     # trying to happen
     monkeypatch.setattr(
-            "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
+        "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
     )
 
     def _send_input(cls, channel_input, **kwargs):
@@ -175,7 +176,7 @@ def test_send_command_ignore_privilege_level(monkeypatch, sync_network_driver):
     assert _acquire_priv_called
     _acquire_priv_called = False
 
-    sync_network_driver.ignore_privilege_level= True
+    sync_network_driver.ignore_privilege_level = True
     sync_network_driver.send_command(
         command="show version",
     )
@@ -226,7 +227,7 @@ def test_send_commands_ignore_privilege_level(monkeypatch, sync_network_driver):
     # patching acquire priv so we know its called but dont have to worry about that actually
     # trying to happen
     monkeypatch.setattr(
-            "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
+        "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
     )
 
     _command_counter = 0
@@ -239,17 +240,13 @@ def test_send_commands_ignore_privilege_level(monkeypatch, sync_network_driver):
     sync_network_driver._current_priv_level = sync_network_driver.privilege_levels["privilege_exec"]
     sync_network_driver.default_desired_privilege_level = "exec"
 
-    sync_network_driver.ignore_privilege_level= False
-    sync_network_driver.send_commands(
-        commands=["show version", "show run"]
-    )
+    sync_network_driver.ignore_privilege_level = False
+    sync_network_driver.send_commands(commands=["show version", "show run"])
     assert _acquire_priv_called
     _acquire_priv_called = False
 
-    sync_network_driver.ignore_privilege_level= True
-    sync_network_driver.send_commands(
-        commands=["show version", "show run"]
-    )
+    sync_network_driver.ignore_privilege_level = True
+    sync_network_driver.send_commands(commands=["show version", "show run"])
     assert not _acquire_priv_called
 
 
@@ -295,7 +292,7 @@ def test_send_commands_from_file_ignore_privilege_level(
     # patching acquire priv so we know its called but dont have to worry about that actually
     # trying to happen
     monkeypatch.setattr(
-            "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
+        "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
     )
 
     fs.add_real_file(source_path=real_ssh_commands_file_path, target_path="/commands")
@@ -308,12 +305,12 @@ def test_send_commands_from_file_ignore_privilege_level(
     sync_network_driver._current_priv_level = sync_network_driver.privilege_levels["privilege_exec"]
     sync_network_driver.default_desired_privilege_level = "exec"
 
-    sync_network_driver.ignore_privilege_level= False
+    sync_network_driver.ignore_privilege_level = False
     sync_network_driver.send_commands_from_file(file="commands")
     assert _acquire_priv_called
     _acquire_priv_called = False
 
-    sync_network_driver.ignore_privilege_level= True
+    sync_network_driver.ignore_privilege_level = True
     sync_network_driver.send_commands_from_file(file="commands")
     assert not _acquire_priv_called
 
@@ -355,14 +352,14 @@ def test_send_interactive_ignore_privilege_level(monkeypatch, sync_network_drive
     # patching acquire priv so we know its called but dont have to worry about that actually
     # trying to happen
     monkeypatch.setattr(
-            "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
+        "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
     )
 
     def _send_inputs_interact(cls, **kwargs):
         return b"raw", b"processed"
 
     monkeypatch.setattr(
-            "scrapli.channel.sync_channel.Channel.send_inputs_interact", _send_inputs_interact
+        "scrapli.channel.sync_channel.Channel.send_inputs_interact", _send_inputs_interact
     )
 
     sync_network_driver._current_priv_level = sync_network_driver.privilege_levels["privilege_exec"]
@@ -423,7 +420,7 @@ def test_send_configs_ignore_privilege_level(monkeypatch, sync_network_driver):
     # patching acquire priv so we know its called but dont have to worry about that actually
     # trying to happen
     monkeypatch.setattr(
-            "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
+        "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
     )
 
     _command_counter = 0
@@ -437,7 +434,7 @@ def test_send_configs_ignore_privilege_level(monkeypatch, sync_network_driver):
 
     sync_network_driver.ignore_privilege_level = False
     sync_network_driver.send_configs(
-            configs=["interface loopback123", "description tests are boring"]
+        configs=["interface loopback123", "description tests are boring"]
     )
     assert _acquire_priv_called
     _acquire_priv_called = False
@@ -445,10 +442,9 @@ def test_send_configs_ignore_privilege_level(monkeypatch, sync_network_driver):
     sync_network_driver.ignore_privilege_level = True
 
     sync_network_driver.send_configs(
-            configs=["interface loopback123", "description tests are boring"]
+        configs=["interface loopback123", "description tests are boring"]
     )
     assert not _acquire_priv_called
-
 
 
 def test_send_config(monkeypatch, sync_network_driver):

--- a/tests/unit/driver/network/test_network_sync_driver.py
+++ b/tests/unit/driver/network/test_network_sync_driver.py
@@ -1,10 +1,11 @@
 import sys
+from unittest.mock import patch
 
 import pytest
 
-from unittest.mock import patch
-from scrapli.exceptions import ScrapliPrivilegeError
 from scrapli.driver.network import NetworkDriver
+from scrapli.exceptions import ScrapliPrivilegeError
+
 
 def test_escalate(monkeypatch, sync_network_driver):
     def _send_input(cls, channel_input, **kwargs):
@@ -147,7 +148,6 @@ def test_send_command(monkeypatch, sync_network_driver):
 
 
 def test_send_command_ignore_privilege_level(monkeypatch, sync_network_driver):
-
     def _send_input(cls, channel_input, **kwargs):
         assert channel_input == "show version"
         return b"raw", b"processed"
@@ -158,14 +158,16 @@ def test_send_command_ignore_privilege_level(monkeypatch, sync_network_driver):
     sync_network_driver.default_desired_privilege_level = "exec"
 
     with patch.object(target=NetworkDriver, attribute="acquire_priv") as mocked_method:
-        sync_network_driver.send_command(command="show version",
-                                         ignore_privilege_level=True,
-                                         )
+        sync_network_driver.send_command(
+            command="show version",
+            ignore_privilege_level=True,
+        )
         mocked_method.assert_not_called()
 
-        sync_network_driver.send_command(command="show version",
-                                         ignore_privilege_level=False,
-                                         )
+        sync_network_driver.send_command(
+            command="show version",
+            ignore_privilege_level=False,
+        )
         mocked_method.assert_called()
 
 
@@ -215,10 +217,14 @@ def test_send_commands_ignore_privilege_level(monkeypatch, sync_network_driver):
     sync_network_driver.default_desired_privilege_level = "exec"
 
     with patch.object(target=NetworkDriver, attribute="acquire_priv") as mocked_method:
-        sync_network_driver.send_commands(commands=["show version", "show run"], ignore_privilege_level=True)
+        sync_network_driver.send_commands(
+            commands=["show version", "show run"], ignore_privilege_level=True
+        )
         mocked_method.assert_not_called()
 
-        sync_network_driver.send_commands(commands=["show version", "show run"], ignore_privilege_level=False)
+        sync_network_driver.send_commands(
+            commands=["show version", "show run"], ignore_privilege_level=False
+        )
         mocked_method.assert_called()
 
 
@@ -251,7 +257,9 @@ def test_send_commands_from_file(fs, monkeypatch, real_ssh_commands_file_path, s
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 10), reason="skipping pending pyfakefs 3.10 support")
-def test_send_commands_from_file_ignore_privilege_level(fs, monkeypatch, real_ssh_commands_file_path, sync_network_driver):
+def test_send_commands_from_file_ignore_privilege_level(
+    fs, monkeypatch, real_ssh_commands_file_path, sync_network_driver
+):
     fs.add_real_file(source_path=real_ssh_commands_file_path, target_path="/commands")
 
     def _send_input(cls, channel_input, **kwargs):

--- a/tests/unit/driver/network/test_network_sync_driver.py
+++ b/tests/unit/driver/network/test_network_sync_driver.py
@@ -412,6 +412,45 @@ def test_send_configs(monkeypatch, sync_network_driver):
     assert actual_response[0].raw_result == b"raw"
 
 
+def test_send_configs_ignore_privilege_level(monkeypatch, sync_network_driver):
+    _acquire_priv_called = False
+
+    def _acquire_priv(cls, **kwargs):
+        nonlocal _acquire_priv_called
+        _acquire_priv_called = True
+        return
+
+    # patching acquire priv so we know its called but dont have to worry about that actually
+    # trying to happen
+    monkeypatch.setattr(
+            "scrapli.driver.network.sync_driver.NetworkDriver.acquire_priv", _acquire_priv
+    )
+
+    _command_counter = 0
+
+    def _send_input(cls, channel_input, **kwargs):
+        return b"raw", b"processed"
+
+    monkeypatch.setattr("scrapli.channel.sync_channel.Channel.send_input", _send_input)
+
+    sync_network_driver._current_priv_level = sync_network_driver.privilege_levels["privilege_exec"]
+
+    sync_network_driver.ignore_privilege_level = False
+    sync_network_driver.send_configs(
+            configs=["interface loopback123", "description tests are boring"]
+    )
+    assert _acquire_priv_called
+    _acquire_priv_called = False
+
+    sync_network_driver.ignore_privilege_level = True
+
+    sync_network_driver.send_configs(
+            configs=["interface loopback123", "description tests are boring"]
+    )
+    assert not _acquire_priv_called
+
+
+
 def test_send_config(monkeypatch, sync_network_driver):
     def _acquire_priv(cls, **kwargs):
         return

--- a/tests/unit/driver/network/test_network_sync_driver.py
+++ b/tests/unit/driver/network/test_network_sync_driver.py
@@ -202,6 +202,26 @@ def test_send_commands(monkeypatch, sync_network_driver):
     assert actual_response[0].raw_result == b"raw"
 
 
+def test_send_commands_ignore_privilege_level(monkeypatch, sync_network_driver):
+
+    _command_counter = 0
+
+    def _send_input(cls, channel_input, **kwargs):
+        return b"raw", b"processed"
+
+    monkeypatch.setattr("scrapli.channel.sync_channel.Channel.send_input", _send_input)
+
+    sync_network_driver._current_priv_level = sync_network_driver.privilege_levels["privilege_exec"]
+    sync_network_driver.default_desired_privilege_level = "exec"
+
+    with patch.object(target=NetworkDriver, attribute="acquire_priv") as mocked_method:
+        sync_network_driver.send_commands(commands=["show version", "show run"], ignore_privilege_level=True)
+        mocked_method.assert_not_called()
+
+        sync_network_driver.send_commands(commands=["show version", "show run"], ignore_privilege_level=False)
+        mocked_method.assert_called()
+
+
 @pytest.mark.skipif(sys.version_info >= (3, 10), reason="skipping pending pyfakefs 3.10 support")
 def test_send_commands_from_file(fs, monkeypatch, real_ssh_commands_file_path, sync_network_driver):
     fs.add_real_file(source_path=real_ssh_commands_file_path, target_path="/commands")


### PR DESCRIPTION
# Description

Added ignore_privilege_level flag to send_command, send_command, and send_commands_from_file. This will allow the user to use whatever the current privilege level is on the device. This will ignore Scrapli's handling of different privilege levels.

Read more information at issue #137  

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added unittests for each of the methods that were modified with the ignore_privilege_level flag. For the unittesting aquire_priv.assert_not_called when ignore_privilege_level=True and aquire_priv.assert_called when ignore_privilege_level=False.


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
