### PR TITLE
Fix NX-OS subinterface ScrapliPrivilegeError exception

### DIFF
--- a/scrapli/driver/core/cisco_nxos/base_driver.py
+++ b/scrapli/driver/core/cisco_nxos/base_driver.py
@@ -38,6 +38,7 @@ PRIVS = {
             escalate_auth=False,
             escalate_prompt="",
             not_contains=["config-tcl", "config-s"],
+            not_contains_override=["config-subif"],
         )
     ),
     "tclsh": (

--- a/scrapli/driver/core/cisco_nxos/base_driver.py
+++ b/scrapli/driver/core/cisco_nxos/base_driver.py
@@ -37,7 +37,7 @@ PRIVS = {
             escalate="configure terminal",
             escalate_auth=False,
             escalate_prompt="",
-            not_contains=["config-tcl", "config-s"],
+            not_contains=["config-tcl", "config-s)", "config-s-"],
         )
     ),
     "tclsh": (

--- a/scrapli/driver/core/cisco_nxos/base_driver.py
+++ b/scrapli/driver/core/cisco_nxos/base_driver.py
@@ -38,7 +38,6 @@ PRIVS = {
             escalate_auth=False,
             escalate_prompt="",
             not_contains=["config-tcl", "config-s"],
-            not_contains_override=["config-subif"],
         )
     ),
     "tclsh": (

--- a/scrapli/driver/network/base_driver.py
+++ b/scrapli/driver/network/base_driver.py
@@ -22,7 +22,6 @@ class PrivilegeLevel:
         "escalate_auth",
         "escalate_prompt",
         "not_contains",
-        "not_contains_override",
     )
 
     def __init__(
@@ -35,7 +34,6 @@ class PrivilegeLevel:
         escalate_auth: bool,
         escalate_prompt: str,
         not_contains: Optional[List[str]] = None,
-        not_contains_override: Optional[List[str]] = None,
     ):
         """
         PrivilegeLevel Object
@@ -50,8 +48,6 @@ class PrivilegeLevel:
             escalate_prompt: prompt pattern to search for during escalation if escalate auth is True
             not_contains: list of substrings that should *not* be seen in a prompt for this
                 privilege level
-            not_contains_override: list of substrings that are allowed to be in a prompt for this
-                privilege level if a substring in `not_contains` is matched.
 
         Returns:
             None
@@ -68,7 +64,6 @@ class PrivilegeLevel:
         self.escalate_auth = escalate_auth
         self.escalate_prompt = escalate_prompt
         self.not_contains: List[str] = not_contains or list()
-        self.not_contains_override: List[str] = not_contains_override or list()
 
 
 DUMMY_PRIV_LEVEL = PrivilegeLevel("", "DUMMY", "", "", "", False, "")
@@ -130,20 +125,12 @@ class BaseNetworkDriver:
         matching_priv_levels = []
         for priv_level in self.privilege_levels.values():
             if priv_level.not_contains:
-                # starting at 2021.07.30 the `not_contains` and `not_contains_override` fields were
-                # added to privilege levels (defaulting to empty tuples) -- this helps us to
-                # simplify the priv patterns greatly, as well as have no reliance on look arounds
-                # which makes the "normal" scrapli privilege levels more go friendly -- useful for
-                # scrapligo!
+                # starting at 2021.07.30 the `not_contains` field was added to privilege levels
+                # (defaulting to an empty tuple) -- this helps us to simplify the priv patterns
+                # greatly, as well as have no reliance on look arounds which makes the "normal"
+                # scrapli privilege levels more go friendly -- useful for scrapligo!
                 if any(not_contains in current_prompt for not_contains in priv_level.not_contains):
-                    if not (
-                        priv_level.not_contains_override
-                        and any(
-                            override in current_prompt
-                            for override in priv_level.not_contains_override
-                        )
-                    ):
-                        continue
+                    continue
 
             search_result = re.search(
                 pattern=priv_level.pattern, string=current_prompt, flags=re.M | re.I

--- a/scrapli/driver/network/base_driver.py
+++ b/scrapli/driver/network/base_driver.py
@@ -67,7 +67,6 @@ class PrivilegeLevel:
         self.escalate = escalate
         self.escalate_auth = escalate_auth
         self.escalate_prompt = escalate_prompt
-        self.not_equals: List[str] = not_equals or list()
         self.not_contains: List[str] = not_contains or list()
         self.not_contains_override: List[str] = not_contains_override or list()
 

--- a/tests/unit/driver/core/cisco_nxos/test_cisco_nxos_base_driver.py
+++ b/tests/unit/driver/core/cisco_nxos/test_cisco_nxos_base_driver.py
@@ -11,6 +11,11 @@ from scrapli.exceptions import ScrapliValueError
     [
         ("exec", "switch>"),
         ("privilege_exec", "switch# "),
+        ("configuration", "switch(config)# "),
+        ("configuration", "switch(config-if)# "),
+        ("configuration", "switch(config-subif)# "),
+        ("configuration", "switch(config-vpc-domain)# "),
+        ("configuration", "switch(config-router)# "),
         ("privilege_exec", "swi_tch# "),
         ("configuration", "switch(config)# "),
         ("tclsh", "switch-tcl# "),
@@ -19,6 +24,11 @@ from scrapli.exceptions import ScrapliValueError
     ids=[
         "exec",
         "privilege_exec",
+        "configuration",
+        "configuration_interface",
+        "configuration_subinterface",
+        "configuration_vpc_domain",
+        "configuration_routing_protocol",
         "underscore_privilege_exec",
         "configuration",
         "tclsh",

--- a/tests/unit/driver/core/cisco_nxos/test_cisco_nxos_base_driver.py
+++ b/tests/unit/driver/core/cisco_nxos/test_cisco_nxos_base_driver.py
@@ -11,11 +11,6 @@ from scrapli.exceptions import ScrapliValueError
     [
         ("exec", "switch>"),
         ("privilege_exec", "switch# "),
-        ("configuration", "switch(config)# "),
-        ("configuration", "switch(config-if)# "),
-        ("configuration", "switch(config-subif)# "),
-        ("configuration", "switch(config-vpc-domain)# "),
-        ("configuration", "switch(config-router)# "),
         ("privilege_exec", "swi_tch# "),
         ("configuration", "switch(config)# "),
         ("tclsh", "switch-tcl# "),
@@ -24,11 +19,6 @@ from scrapli.exceptions import ScrapliValueError
     ids=[
         "exec",
         "privilege_exec",
-        "configuration",
-        "configuration_interface",
-        "configuration_subinterface",
-        "configuration_vpc_domain",
-        "configuration_routing_protocol",
         "underscore_privilege_exec",
         "configuration",
         "tclsh",


### PR DESCRIPTION
# Description

Prior to this PR, the `send_configs` coroutine would result in a ScrapliPrivilegeError exception if the list of configuration strings ended in subinterface configuration. This configuration leaves the device prompt looking like the following:
```
switch(config-subif)# 
```

The resulting ScrapliPrivilegeError exception is as follows:

```
Traceback (most recent call last):
  File "main.py", line 40, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.8/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "main.py", line 35, in main
    await conn.close()
  File "/home/christopher/Documents/Python/scrapli-test/venv/lib/python3.8/site-packages/scrapli/driver/base/async_driver.py", line 119, in close
    await self.on_close(self)
  File "/home/christopher/Documents/Python/scrapli-test/venv/lib/python3.8/site-packages/scrapli/driver/core/cisco_nxos/async_driver.py", line 44, in nxos_on_close
    await conn.acquire_priv(desired_priv=conn.default_desired_privilege_level)
  File "/home/christopher/Documents/Python/scrapli-test/venv/lib/python3.8/site-packages/scrapli/driver/network/async_driver.py", line 147, in acquire_priv
    privilege_action, target_priv = self._process_acquire_priv(
  File "/home/christopher/Documents/Python/scrapli-test/venv/lib/python3.8/site-packages/scrapli/driver/network/base_driver.py", line 330, in _process_acquire_priv
    current_priv_patterns = self._determine_current_priv(current_prompt=current_prompt)
  File "/home/christopher/Documents/Python/scrapli-test/venv/lib/python3.8/site-packages/scrapli/driver/network/base_driver.py", line 145, in _determine_current_priv
    raise ScrapliPrivilegeError(msg)
scrapli.exceptions.ScrapliPrivilegeError: could not determine privilege level from provided prompt: 'NX-OS(config-subif)#'
```

The root cause of this is the new `not_contains` field under the PrivilegeLevel object, which contains `config-s` for the `configuration` NX-OS privilege. Since `config-s` is a substring of `config-subif`, the prompt is ignored and the ScrapliPrivilegeError exception is raised.

This PR fixes this by adding the following:

1. A new `not_contains_override` field under the PrivilegeLevel object
2. Additional logic under the `any()` comprehension that iterates through the `not_contains` field that verifies whether any substring in the `not_contains_override` field is present in the prompt.
3. Added the `config_subif` substring to the `not_contains_override` field under the NX-OS base driver.
4. Unit tests for this scenario.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested through additional unit tests for the NX-OS base driver.

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes