### PR TITLE
Fixes endless loops in telnet open and auth if server sends EOFs, closes #142

### DIFF
--- a/docs/api_docs/channel/async_channel.md
+++ b/docs/api_docs/channel/async_channel.md
@@ -347,6 +347,7 @@ class AsyncChannel(BaseChannel):
         search_pattern = self._get_prompt_pattern(
             class_pattern=self._base_channel_args.comms_prompt_pattern
         )
+        max_auth_return_retry = self._base_channel_args.max_auth_return_retry
 
         # capture the start time of the authentication event; we also set a "return_interval" which
         # is 1/10 the timout_ops value, we will send a return character at roughly this interval if
@@ -361,6 +362,12 @@ class AsyncChannel(BaseChannel):
                 buf = await self.read()
 
                 if not buf:
+                    if return_attempts >= max_auth_return_retry:
+                        msg = "nothing returned from server after " + \
+                            str(return_attempts) + \
+                            " retries, assuming auth failed"
+                        self.logger.critical(msg)
+                        raise ScrapliAuthenticationFailed(msg)
                     current_iteration_time = datetime.now().timestamp()
                     if (current_iteration_time - auth_start_time) > (
                         return_interval * return_attempts
@@ -969,6 +976,7 @@ class AsyncChannel(BaseChannel):
         search_pattern = self._get_prompt_pattern(
             class_pattern=self._base_channel_args.comms_prompt_pattern
         )
+        max_auth_return_retry = self._base_channel_args.max_auth_return_retry
 
         # capture the start time of the authentication event; we also set a "return_interval" which
         # is 1/10 the timout_ops value, we will send a return character at roughly this interval if
@@ -983,6 +991,12 @@ class AsyncChannel(BaseChannel):
                 buf = await self.read()
 
                 if not buf:
+                    if return_attempts >= max_auth_return_retry:
+                        msg = "nothing returned from server after " + \
+                            str(return_attempts) + \
+                            " retries, assuming auth failed"
+                        self.logger.critical(msg)
+                        raise ScrapliAuthenticationFailed(msg)
                     current_iteration_time = datetime.now().timestamp()
                     if (current_iteration_time - auth_start_time) > (
                         return_interval * return_attempts

--- a/docs/api_docs/channel/base_channel.md
+++ b/docs/api_docs/channel/base_channel.md
@@ -61,6 +61,8 @@ class BaseChannelArgs:
         channel_log_mode: "write"|"append", all other values will raise ValueError,
             does what it sounds like it should by setting the channel log to the provided mode
         channel_lock: bool indicated if channel lock should be used for all read/write operations
+        max_auth_return_retry: maximum number of retries for sending return key to server when
+            trying to authenticate
 
     Returns:
         None
@@ -77,6 +79,7 @@ class BaseChannelArgs:
     channel_log: Union[str, bool, BytesIO] = False
     channel_log_mode: str = "write"
     channel_lock: bool = False
+    max_auth_return_retry: int = 10
 
     def __post_init__(self) -> None:
         """
@@ -868,6 +871,8 @@ Args:
     channel_log_mode: "write"|"append", all other values will raise ValueError,
         does what it sounds like it should by setting the channel log to the provided mode
     channel_lock: bool indicated if channel lock should be used for all read/write operations
+    max_auth_return_retry: maximum number of retries for sending return key to server when
+        trying to authenticate
 
 Returns:
     None
@@ -901,6 +906,8 @@ class BaseChannelArgs:
         channel_log_mode: "write"|"append", all other values will raise ValueError,
             does what it sounds like it should by setting the channel log to the provided mode
         channel_lock: bool indicated if channel lock should be used for all read/write operations
+        max_auth_return_retry: maximum number of retries for sending return key to server when
+            trying to authenticate
 
     Returns:
         None
@@ -917,6 +924,7 @@ class BaseChannelArgs:
     channel_log: Union[str, bool, BytesIO] = False
     channel_log_mode: str = "write"
     channel_lock: bool = False
+    max_auth_return_retry: int = 10
 
     def __post_init__(self) -> None:
         """
@@ -984,6 +992,12 @@ class BaseChannelArgs:
 
     
 `comms_return_char: str`
+
+
+
+
+    
+`max_auth_return_retry: int`
 
 
 

--- a/docs/api_docs/channel/sync_channel.md
+++ b/docs/api_docs/channel/sync_channel.md
@@ -336,6 +336,7 @@ class Channel(BaseChannel):
         search_pattern = self._get_prompt_pattern(
             class_pattern=self._base_channel_args.comms_prompt_pattern
         )
+        max_auth_return_retry = self._base_channel_args.max_auth_return_retry
 
         # capture the start time of the authentication event; we also set a "return_interval" which
         # is 1/10 the timout_ops value, we will send a return character at roughly this interval if
@@ -350,6 +351,12 @@ class Channel(BaseChannel):
                 buf = self.read()
 
                 if not buf:
+                    if return_attempts >= max_auth_return_retry:
+                        msg = "nothing returned from server after " + \
+                            str(return_attempts) + \
+                            " retries, assuming auth failed"
+                        self.logger.critical(msg)
+                        raise ScrapliAuthenticationFailed(msg)
                     current_iteration_time = datetime.now().timestamp()
                     if (current_iteration_time - auth_start_time) > (
                         return_interval * return_attempts
@@ -953,6 +960,7 @@ class Channel(BaseChannel):
         search_pattern = self._get_prompt_pattern(
             class_pattern=self._base_channel_args.comms_prompt_pattern
         )
+        max_auth_return_retry = self._base_channel_args.max_auth_return_retry
 
         # capture the start time of the authentication event; we also set a "return_interval" which
         # is 1/10 the timout_ops value, we will send a return character at roughly this interval if
@@ -967,6 +975,12 @@ class Channel(BaseChannel):
                 buf = self.read()
 
                 if not buf:
+                    if return_attempts >= max_auth_return_retry:
+                        msg = "nothing returned from server after " + \
+                            str(return_attempts) + \
+                            " retries, assuming auth failed"
+                        self.logger.critical(msg)
+                        raise ScrapliAuthenticationFailed(msg)
                     current_iteration_time = datetime.now().timestamp()
                     if (current_iteration_time - auth_start_time) > (
                         return_interval * return_attempts

--- a/docs/api_docs/driver/base/async_driver.md
+++ b/docs/api_docs/driver/base/async_driver.md
@@ -342,6 +342,8 @@ Args:
     logging_uid: unique identifier (string) to associate to log messages; useful if you have
         multiple connections to the same device (i.e. one console, one ssh, or one to each
         supervisor module, etc.)
+    max_auth_return_retry: maximum number of retries for sending return key to server when
+        trying to authenticate
 
 Returns:
     None

--- a/docs/api_docs/driver/base/base_driver.md
+++ b/docs/api_docs/driver/base/base_driver.md
@@ -74,6 +74,7 @@ class BaseDriver:
         channel_log_mode: str = "write",
         channel_lock: bool = False,
         logging_uid: str = "",
+        max_auth_return_retry: int = 10,
     ) -> None:
         r"""
         BaseDriver Object
@@ -149,6 +150,8 @@ class BaseDriver:
             logging_uid: unique identifier (string) to associate to log messages; useful if you have
                 multiple connections to the same device (i.e. one console, one ssh, or one to each
                 supervisor module, etc.)
+            max_auth_return_retry: maximum number of retries for sending return key to server when
+                trying to authenticate
 
         Returns:
             None
@@ -168,6 +171,7 @@ class BaseDriver:
             channel_log=channel_log,
             channel_log_mode=channel_log_mode,
             channel_lock=channel_lock,
+            max_auth_return_retry=max_auth_return_retry,
         )
 
         # transport options is unused in most transport plugins, but when used will be a dict of
@@ -276,6 +280,7 @@ class BaseDriver:
             f"transport_options={self._base_transport_args.transport_options!r})"
             f"channel_log={self._base_channel_args.channel_log!r}, "
             f"channel_lock={self._base_channel_args.channel_lock!r})"
+            f"max_auth_return_retry={self._base_channel_args.max_auth_return_retry!r}, "
         )
 
     @staticmethod
@@ -885,6 +890,45 @@ class BaseDriver:
             self.logger.debug("'timeout_ops' value is 0, this will disable timeout decorator")
 
         self._base_channel_args.timeout_ops = value
+
+    @property
+    def max_auth_return_retry(self) -> str:
+        """
+        Getter for `max_auth_return_retry` attribute
+
+        Args:
+            N/A
+
+        Returns:
+            int: max_auth_return_retry integer
+
+        Raises:
+            N/A
+
+        """
+        return self._base_channel_args.max_auth_return_retry
+
+    @max_auth_return_retry.setter
+    def max_auth_return_retry(self, value: str) -> None:
+        """
+        Setter for `max_auth_return_retry` attribute
+
+        Args:
+            value: int value for max_auth_return_retry
+
+        Returns:
+            None
+
+        Raises:
+            ScrapliTypeError: if value is not of type str
+
+        """
+        self.logger.debug(f"setting 'max_auth_return_retry' value to '{value}'")
+
+        if not isinstance(value, str):
+            raise ScrapliTypeError
+
+        self._base_channel_args.max_auth_return_retry = value
 
     def isalive(self) -> bool:
         """
@@ -1026,6 +1070,8 @@ Args:
     logging_uid: unique identifier (string) to associate to log messages; useful if you have
         multiple connections to the same device (i.e. one console, one ssh, or one to each
         supervisor module, etc.)
+    max_auth_return_retry: maximum number of retries for sending return key to server when
+        trying to authenticate
 
 Returns:
     None
@@ -1068,6 +1114,7 @@ class BaseDriver:
         channel_log_mode: str = "write",
         channel_lock: bool = False,
         logging_uid: str = "",
+        max_auth_return_retry: int = 10,
     ) -> None:
         r"""
         BaseDriver Object
@@ -1143,6 +1190,8 @@ class BaseDriver:
             logging_uid: unique identifier (string) to associate to log messages; useful if you have
                 multiple connections to the same device (i.e. one console, one ssh, or one to each
                 supervisor module, etc.)
+            max_auth_return_retry: maximum number of retries for sending return key to server when
+                trying to authenticate
 
         Returns:
             None
@@ -1162,6 +1211,7 @@ class BaseDriver:
             channel_log=channel_log,
             channel_log_mode=channel_log_mode,
             channel_lock=channel_lock,
+            max_auth_return_retry=max_auth_return_retry,
         )
 
         # transport options is unused in most transport plugins, but when used will be a dict of
@@ -1270,6 +1320,7 @@ class BaseDriver:
             f"transport_options={self._base_transport_args.transport_options!r})"
             f"channel_log={self._base_channel_args.channel_log!r}, "
             f"channel_lock={self._base_channel_args.channel_lock!r})"
+            f"max_auth_return_retry={self._base_channel_args.max_auth_return_retry!r}, "
         )
 
     @staticmethod
@@ -1880,6 +1931,45 @@ class BaseDriver:
 
         self._base_channel_args.timeout_ops = value
 
+    @property
+    def max_auth_return_retry(self) -> str:
+        """
+        Getter for `max_auth_return_retry` attribute
+
+        Args:
+            N/A
+
+        Returns:
+            int: max_auth_return_retry integer
+
+        Raises:
+            N/A
+
+        """
+        return self._base_channel_args.max_auth_return_retry
+
+    @max_auth_return_retry.setter
+    def max_auth_return_retry(self, value: str) -> None:
+        """
+        Setter for `max_auth_return_retry` attribute
+
+        Args:
+            value: int value for max_auth_return_retry
+
+        Returns:
+            None
+
+        Raises:
+            ScrapliTypeError: if value is not of type str
+
+        """
+        self.logger.debug(f"setting 'max_auth_return_retry' value to '{value}'")
+
+        if not isinstance(value, str):
+            raise ScrapliTypeError
+
+        self._base_channel_args.max_auth_return_retry = value
+
     def isalive(self) -> bool:
         """
         Check if underlying transport is "alive"
@@ -1973,6 +2063,24 @@ Args:
 
 Returns:
     str: comms_return_char string
+
+Raises:
+    N/A
+```
+
+
+
+    
+`max_auth_return_retry: str`
+
+```text
+Getter for `max_auth_return_retry` attribute
+
+Args:
+    N/A
+
+Returns:
+    int: max_auth_return_retry integer
 
 Raises:
     N/A

--- a/docs/api_docs/driver/base/sync_driver.md
+++ b/docs/api_docs/driver/base/sync_driver.md
@@ -293,6 +293,8 @@ Args:
     logging_uid: unique identifier (string) to associate to log messages; useful if you have
         multiple connections to the same device (i.e. one console, one ssh, or one to each
         supervisor module, etc.)
+    max_auth_return_retry: maximum number of retries for sending return key to server when
+        trying to authenticate
 
 Returns:
     None

--- a/docs/api_docs/driver/generic/async_driver.md
+++ b/docs/api_docs/driver/generic/async_driver.md
@@ -66,6 +66,7 @@ class AsyncGenericDriver(AsyncDriver, BaseGenericDriver):
         channel_log: Union[str, bool, BytesIO] = False,
         channel_lock: bool = False,
         logging_uid: str = "",
+        max_auth_return_retry: int = 10,
     ) -> None:
         super().__init__(
             host=host,
@@ -92,6 +93,7 @@ class AsyncGenericDriver(AsyncDriver, BaseGenericDriver):
             channel_log=channel_log,
             channel_lock=channel_lock,
             logging_uid=logging_uid,
+            max_auth_return_retry=max_auth_return_retry,
         )
 
     async def get_prompt(self) -> str:
@@ -546,6 +548,8 @@ Args:
     logging_uid: unique identifier (string) to associate to log messages; useful if you have
         multiple connections to the same device (i.e. one console, one ssh, or one to each
         supervisor module, etc.)
+    max_auth_return_retry: maximum number of retries for sending return key to server when
+        trying to authenticate
 
 Returns:
     None
@@ -587,6 +591,7 @@ class AsyncGenericDriver(AsyncDriver, BaseGenericDriver):
         channel_log: Union[str, bool, BytesIO] = False,
         channel_lock: bool = False,
         logging_uid: str = "",
+        max_auth_return_retry: int = 10,
     ) -> None:
         super().__init__(
             host=host,
@@ -613,6 +618,7 @@ class AsyncGenericDriver(AsyncDriver, BaseGenericDriver):
             channel_log=channel_log,
             channel_lock=channel_lock,
             logging_uid=logging_uid,
+            max_auth_return_retry=max_auth_return_retry,
         )
 
     async def get_prompt(self) -> str:

--- a/docs/api_docs/driver/generic/sync_driver.md
+++ b/docs/api_docs/driver/generic/sync_driver.md
@@ -66,6 +66,7 @@ class GenericDriver(Driver, BaseGenericDriver):
         channel_log: Union[str, bool, BytesIO] = False,
         channel_lock: bool = False,
         logging_uid: str = "",
+        max_auth_return_retry: int = 10,
     ) -> None:
         super().__init__(
             host=host,
@@ -92,6 +93,7 @@ class GenericDriver(Driver, BaseGenericDriver):
             channel_log=channel_log,
             channel_lock=channel_lock,
             logging_uid=logging_uid,
+            max_auth_return_retry=max_auth_return_retry,
         )
 
     def get_prompt(self) -> str:
@@ -547,6 +549,8 @@ Args:
     logging_uid: unique identifier (string) to associate to log messages; useful if you have
         multiple connections to the same device (i.e. one console, one ssh, or one to each
         supervisor module, etc.)
+    max_auth_return_retry: maximum number of retries for sending return key to server when
+        trying to authenticate
 
 Returns:
     None
@@ -588,6 +592,7 @@ class GenericDriver(Driver, BaseGenericDriver):
         channel_log: Union[str, bool, BytesIO] = False,
         channel_lock: bool = False,
         logging_uid: str = "",
+        max_auth_return_retry: int = 10,
     ) -> None:
         super().__init__(
             host=host,
@@ -614,6 +619,7 @@ class GenericDriver(Driver, BaseGenericDriver):
             channel_log=channel_log,
             channel_lock=channel_lock,
             logging_uid=logging_uid,
+            max_auth_return_retry=max_auth_return_retry,
         )
 
     def get_prompt(self) -> str:

--- a/docs/api_docs/driver/network/async_driver.md
+++ b/docs/api_docs/driver/network/async_driver.md
@@ -713,6 +713,8 @@ Args:
     logging_uid: unique identifier (string) to associate to log messages; useful if you have
         multiple connections to the same device (i.e. one console, one ssh, or one to each
         supervisor module, etc.)
+    max_auth_return_retry: maximum number of retries for sending return key to server when
+        trying to authenticate
 
 Returns:
     None

--- a/docs/api_docs/driver/network/sync_driver.md
+++ b/docs/api_docs/driver/network/sync_driver.md
@@ -713,6 +713,8 @@ Args:
     logging_uid: unique identifier (string) to associate to log messages; useful if you have
         multiple connections to the same device (i.e. one console, one ssh, or one to each
         supervisor module, etc.)
+    max_auth_return_retry: maximum number of retries for sending return key to server when
+        trying to authenticate
 
 Returns:
     None

--- a/docs/api_docs/factory.md
+++ b/docs/api_docs/factory.md
@@ -926,6 +926,8 @@ Args:
     logging_uid: unique identifier (string) to associate to log messages; useful if you have
         multiple connections to the same device (i.e. one console, one ssh, or one to each
         supervisor module, etc.)
+    max_auth_return_retry: maximum number of retries for sending return key to server when
+        trying to authenticate
 
 Returns:
     None
@@ -1374,6 +1376,8 @@ Args:
     logging_uid: unique identifier (string) to associate to log messages; useful if you have
         multiple connections to the same device (i.e. one console, one ssh, or one to each
         supervisor module, etc.)
+    max_auth_return_retry: maximum number of retries for sending return key to server when
+        trying to authenticate
 
 Returns:
     None

--- a/docs/api_docs/transport/plugins/asynctelnet.md
+++ b/docs/api_docs/transport/plugins/asynctelnet.md
@@ -157,6 +157,8 @@ class AsynctelnetTransport(AsyncTransport):
         while True:
             try:
                 c = await asyncio.wait_for(self.stdout.read(1), timeout=char_read_timeout)
+                if not c:
+                    break
             except asyncio.TimeoutError:
                 return
             char_read_timeout = self._base_transport_args.timeout_socket / 10
@@ -372,6 +374,8 @@ class AsynctelnetTransport(AsyncTransport):
         while True:
             try:
                 c = await asyncio.wait_for(self.stdout.read(1), timeout=char_read_timeout)
+                if not c:
+                    break
             except asyncio.TimeoutError:
                 return
             char_read_timeout = self._base_transport_args.timeout_socket / 10

--- a/scrapli/channel/async_channel.py
+++ b/scrapli/channel/async_channel.py
@@ -317,6 +317,7 @@ class AsyncChannel(BaseChannel):
         search_pattern = self._get_prompt_pattern(
             class_pattern=self._base_channel_args.comms_prompt_pattern
         )
+        max_auth_return_retry = self._base_channel_args.max_auth_return_retry
 
         # capture the start time of the authentication event; we also set a "return_interval" which
         # is 1/10 the timout_ops value, we will send a return character at roughly this interval if
@@ -331,6 +332,12 @@ class AsyncChannel(BaseChannel):
                 buf = await self.read()
 
                 if not buf:
+                    if return_attempts >= max_auth_return_retry:
+                        msg = "nothing returned from server after " + \
+                            str(return_attempts) + \
+                            " retries, assuming auth failed"
+                        self.logger.critical(msg)
+                        raise ScrapliAuthenticationFailed(msg)
                     current_iteration_time = datetime.now().timestamp()
                     if (current_iteration_time - auth_start_time) > (
                         return_interval * return_attempts

--- a/scrapli/channel/base_channel.py
+++ b/scrapli/channel/base_channel.py
@@ -31,6 +31,8 @@ class BaseChannelArgs:
         channel_log_mode: "write"|"append", all other values will raise ValueError,
             does what it sounds like it should by setting the channel log to the provided mode
         channel_lock: bool indicated if channel lock should be used for all read/write operations
+        max_auth_return_retry: maximum number of retries for sending return key to server when
+            trying to authenticate
 
     Returns:
         None
@@ -47,6 +49,7 @@ class BaseChannelArgs:
     channel_log: Union[str, bool, BytesIO] = False
     channel_log_mode: str = "write"
     channel_lock: bool = False
+    max_auth_return_retry: int = 10
 
     def __post_init__(self) -> None:
         """

--- a/scrapli/driver/base/base_driver.py
+++ b/scrapli/driver/base/base_driver.py
@@ -44,6 +44,7 @@ class BaseDriver:
         channel_log_mode: str = "write",
         channel_lock: bool = False,
         logging_uid: str = "",
+        max_auth_return_retry: int = 10,
     ) -> None:
         r"""
         BaseDriver Object
@@ -119,6 +120,8 @@ class BaseDriver:
             logging_uid: unique identifier (string) to associate to log messages; useful if you have
                 multiple connections to the same device (i.e. one console, one ssh, or one to each
                 supervisor module, etc.)
+            max_auth_return_retry: maximum number of retries for sending return key to server when
+                trying to authenticate
 
         Returns:
             None
@@ -138,6 +141,7 @@ class BaseDriver:
             channel_log=channel_log,
             channel_log_mode=channel_log_mode,
             channel_lock=channel_lock,
+            max_auth_return_retry=max_auth_return_retry,
         )
 
         # transport options is unused in most transport plugins, but when used will be a dict of
@@ -246,6 +250,7 @@ class BaseDriver:
             f"transport_options={self._base_transport_args.transport_options!r})"
             f"channel_log={self._base_channel_args.channel_log!r}, "
             f"channel_lock={self._base_channel_args.channel_lock!r})"
+            f"max_auth_return_retry={self._base_channel_args.max_auth_return_retry!r}, "
         )
 
     @staticmethod
@@ -855,6 +860,45 @@ class BaseDriver:
             self.logger.debug("'timeout_ops' value is 0, this will disable timeout decorator")
 
         self._base_channel_args.timeout_ops = value
+
+    @property
+    def max_auth_return_retry(self) -> str:
+        """
+        Getter for `max_auth_return_retry` attribute
+
+        Args:
+            N/A
+
+        Returns:
+            int: max_auth_return_retry integer
+
+        Raises:
+            N/A
+
+        """
+        return self._base_channel_args.max_auth_return_retry
+
+    @max_auth_return_retry.setter
+    def max_auth_return_retry(self, value: str) -> None:
+        """
+        Setter for `max_auth_return_retry` attribute
+
+        Args:
+            value: int value for max_auth_return_retry
+
+        Returns:
+            None
+
+        Raises:
+            ScrapliTypeError: if value is not of type str
+
+        """
+        self.logger.debug(f"setting 'max_auth_return_retry' value to '{value}'")
+
+        if not isinstance(value, str):
+            raise ScrapliTypeError
+
+        self._base_channel_args.max_auth_return_retry = value
 
     def isalive(self) -> bool:
         """

--- a/scrapli/driver/generic/async_driver.py
+++ b/scrapli/driver/generic/async_driver.py
@@ -36,6 +36,7 @@ class AsyncGenericDriver(AsyncDriver, BaseGenericDriver):
         channel_log: Union[str, bool, BytesIO] = False,
         channel_lock: bool = False,
         logging_uid: str = "",
+        max_auth_return_retry: int = 10,
     ) -> None:
         super().__init__(
             host=host,
@@ -62,6 +63,7 @@ class AsyncGenericDriver(AsyncDriver, BaseGenericDriver):
             channel_log=channel_log,
             channel_lock=channel_lock,
             logging_uid=logging_uid,
+            max_auth_return_retry=max_auth_return_retry,
         )
 
     async def get_prompt(self) -> str:

--- a/scrapli/driver/generic/sync_driver.py
+++ b/scrapli/driver/generic/sync_driver.py
@@ -36,6 +36,7 @@ class GenericDriver(Driver, BaseGenericDriver):
         channel_log: Union[str, bool, BytesIO] = False,
         channel_lock: bool = False,
         logging_uid: str = "",
+        max_auth_return_retry: int = 10,
     ) -> None:
         super().__init__(
             host=host,
@@ -62,6 +63,7 @@ class GenericDriver(Driver, BaseGenericDriver):
             channel_log=channel_log,
             channel_lock=channel_lock,
             logging_uid=logging_uid,
+            max_auth_return_retry=max_auth_return_retry,
         )
 
     def get_prompt(self) -> str:

--- a/scrapli/transport/plugins/asynctelnet/transport.py
+++ b/scrapli/transport/plugins/asynctelnet/transport.py
@@ -127,6 +127,8 @@ class AsynctelnetTransport(AsyncTransport):
         while True:
             try:
                 c = await asyncio.wait_for(self.stdout.read(1), timeout=char_read_timeout)
+                if not c:
+                    break
             except asyncio.TimeoutError:
                 return
             char_read_timeout = self._base_transport_args.timeout_socket / 10


### PR DESCRIPTION
# Description

To fix the issue this PR introduces new variable "max_auth_return_retry" of type int that defaults to 10 retries and uses that variable to limit retries with return key in telnet connection on authentication.
Docs updated.
Sorry, can't make a docker switch emulator for this issue - requires too much work.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# How Has This Been Tested?

In the house with my switch that had this problem D-Link DES-1210-28/ME.
To reproduce: have an D-Link DES-1210-28/ME, disable telnet on it, use scrapli to connect with telnet.
The problem is that when telnet is disabled on the switch you still can connect to it throurgh telnet but the switch will only send EOFs.


# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
