### PR TITLE
Add hosts to multiresponse

### DIFF
--- a/scrapli/response.py
+++ b/scrapli/response.py
@@ -248,22 +248,27 @@ class MultiResponse(ScrapliMultiResponse):
         )
 
     @cached_property
-    def hosts(self) -> Set[str]:
+    def host(self) -> str:
         """
-        Return set of hosts that were in the responses
+        Return the host of the multiresponse
 
         Args:
             N/A
 
         Returns:
-            Set: of hosts that are associated with the responses
+            str: The host of the associated responses
 
         Raises:
             N/A
 
         """
-        hosts = set(response.host for response in self.data)
-        return hosts
+        try:
+            response = self.data[0]
+        except IndexError:
+            return ""
+
+        host = response.host
+        return host
 
     @property
     def failed(self) -> bool:

--- a/scrapli/response.py
+++ b/scrapli/response.py
@@ -3,7 +3,7 @@ from collections import UserList
 from datetime import datetime
 from functools import cached_property
 from io import TextIOWrapper
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from scrapli.exceptions import ScrapliCommandFailure
 from scrapli.helper import _textfsm_get_template, genie_parse, textfsm_parse, ttp_parse

--- a/scrapli/response.py
+++ b/scrapli/response.py
@@ -1,7 +1,6 @@
 """scrapli.response"""
 from collections import UserList
 from datetime import datetime
-from functools import cached_property
 from io import TextIOWrapper
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
@@ -246,7 +245,7 @@ class MultiResponse(ScrapliMultiResponse):
             f"Response Elements: {len(self.data)}>"
         )
 
-    @cached_property
+    @property
     def host(self) -> str:
         """
         Return the host of the multiresponse
@@ -265,7 +264,6 @@ class MultiResponse(ScrapliMultiResponse):
             response = self.data[0]
         except IndexError:
             return ""
-
         host = response.host
         return host
 

--- a/scrapli/response.py
+++ b/scrapli/response.py
@@ -85,7 +85,6 @@ class Response:
             N/A
 
         """
-        # return f"{self.__class__} <Success: {str(not self.failed)}>"
         return (
             f"{self.__class__.__name__}("
             f"host={self.host!r},"

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -29,7 +29,9 @@ def test_multi_response():
     host = "localhost"
     response1 = Response(host, "ls -al")
     response2 = Response(host, "ls -al")
-    multi_response = MultiResponse([response1, response2])
+    multi_response = MultiResponse()
+    assert multi_response.host == ""
+    multi_response.extend([response1, response2])
     assert len(multi_response) == 2
     assert multi_response.failed is True
     assert (

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -43,7 +43,7 @@ def test_multi_response():
     multi_response[1].failed = False
     assert multi_response.failed is False
     assert multi_response.raise_for_status() is None
-    assert multi_response.hosts == {host}
+    assert multi_response.host == host
     assert (
         repr(multi_response)
         == "[Response(host='localhost',channel_input='ls -al',textfsm_platform='',genie_platform='',failed_when_contains=None), Response(host='localhost',channel_input='ls -al',textfsm_platform='',genie_platform='',failed_when_contains=None)]"


### PR DESCRIPTION
# Description

I added a `@cached_property` to `MultiResponse` that will return a `set`of hosts that were seen in the responses. This will be helpful when dealing with multiple Scrapli handlers running commands on multiple devices. 

I also fixed the __repr__ for Response and MultiResponse so that it prints the object representation of those objects which will aid in testing.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I modified some of the unit tests for Response to test these changes


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
