### PR TITLE
New feature: `username_prompt` and `password_prompt` as regex

### DIFF
--- a/docs/user_guide/basic_usage.md
+++ b/docs/user_guide/basic_usage.md
@@ -440,6 +440,24 @@ scrapli supports telnet as a transport driver via the standard library module `t
    following attributes of the `Scrape` object:
   - `username_prompt`
   - `password_prompt`
+
+  `username_prompt` and `password_prompt` are regular expressions in string type. This was done to avoid breaking
+  compatibility with older versions of `scrapli`.  
+  Example:
+  ```python
+  device = {
+      "host": "172.18.0.11",
+      "auth_username": "scrapli",
+      "auth_password": "scrapli",
+      "transport": "asynctelnet",
+      "port": 23,
+  }
+  conn = AsyncGenericDriver(**device)
+  conn.transport.username_prompt = "sername:|ogin:"
+  conn.transport.password_prompt = "assword:"
+  conn.open()
+  ```
+
 - When using telnet you may need to set the `comms_return_char` to `\r\n` the tests against the core platforms pass
  without this, however it seems that some console server type devices are looking for this `\r\n` pattern instead of
   the default `\n` pattern.

--- a/scrapli/channel/sync_channel.py
+++ b/scrapli/channel/sync_channel.py
@@ -5,12 +5,14 @@ from contextlib import contextmanager
 from datetime import datetime
 from io import SEEK_END, BytesIO
 from threading import Lock
-from typing import Iterator, List, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple, Union, cast
 
 from scrapli.channel.base_channel import BaseChannel, BaseChannelArgs
 from scrapli.decorators import ChannelTimeout
 from scrapli.exceptions import ScrapliAuthenticationFailed, ScrapliTimeout
 from scrapli.transport.base import Transport
+from scrapli.transport.plugins.asynctelnet.transport import AsynctelnetTransport
+from scrapli.transport.plugins.telnet.transport import TelnetTransport
 
 
 class Channel(BaseChannel):
@@ -298,10 +300,12 @@ class Channel(BaseChannel):
         password_count = 0
         authenticate_buf = b""
 
-        # ignoring type here out of laziness mostly, telnet is kind of special and this should be
-        # the only real one off type thing hopefully
-        bytes_username_prompt = self.transport.username_prompt.encode()  # type: ignore
-        bytes_password_prompt = self.transport.password_prompt.encode()  # type: ignore
+        username_prompt_pattern = cast(
+            Union[AsynctelnetTransport, TelnetTransport], self.transport
+        ).username_prompt.encode("unicode-escape")
+        password_prompt_pattern = cast(
+            Union[AsynctelnetTransport, TelnetTransport], self.transport
+        ).password_prompt.encode("unicode-escape")
 
         search_pattern = self._get_prompt_pattern(
             class_pattern=self._base_channel_args.comms_prompt_pattern
@@ -329,7 +333,11 @@ class Channel(BaseChannel):
 
                 authenticate_buf += buf.lower()
 
-                if bytes_username_prompt in authenticate_buf:
+                username_prompt_match = re.search(
+                    pattern=username_prompt_pattern,
+                    string=authenticate_buf,
+                )
+                if username_prompt_match:
                     # clear the authentication buffer so we don't re-read the username prompt
                     authenticate_buf = b""
                     username_count += 1
@@ -340,7 +348,11 @@ class Channel(BaseChannel):
                     self.write(channel_input=auth_username)
                     self.send_return()
 
-                if bytes_password_prompt in authenticate_buf:
+                password_prompt_match = re.search(
+                    pattern=password_prompt_pattern,
+                    string=authenticate_buf,
+                )
+                if password_prompt_match:
                     # clear the authentication buffer so we don't re-read the password prompt
                     authenticate_buf = b""
                     password_count += 1

--- a/scrapli/transport/plugins/asynctelnet/transport.py
+++ b/scrapli/transport/plugins/asynctelnet/transport.py
@@ -32,7 +32,7 @@ class AsynctelnetTransport(AsyncTransport):
         super().__init__(base_transport_args=base_transport_args)
         self.plugin_transport_args = plugin_transport_args
 
-        self.username_prompt: str = "sername:"
+        self.username_prompt: str = "sername:|ogin:"
         self.password_prompt: str = "assword:"
 
         self.stdout: Optional[asyncio.StreamReader] = None

--- a/scrapli/transport/plugins/telnet/transport.py
+++ b/scrapli/transport/plugins/telnet/transport.py
@@ -43,8 +43,8 @@ class TelnetTransport(Transport):
         super().__init__(base_transport_args=base_transport_args)
         self.plugin_transport_args = plugin_transport_args
 
-        self.username_prompt: str = "username:"
-        self.password_prompt: str = "password:"
+        self.username_prompt: str = "sername:|ogin:"
+        self.password_prompt: str = "assword:"
 
         self.session: Optional[ScrapliTelnet] = None
 


### PR DESCRIPTION
Implements carlmontanari/scrapli#146

# Description

- [x] Implemented `username_prompt` and `password_prompt` as regex
- [x] The changes cover `sync` and `async` telnet versions
- [x] Retained compatibility with older `scrapli` versions. `username_prompt` and `password_prompt` are strings.
- [x] Fixed mypy type issue with `self.transport` in `channel_authenticate_telnet`
- [x] Updated `basic_usage.md` in regards to this change and made an example on how to use this feature
- [x] Fixed mypy warning for complexity in `channel_authenticate_telnet` - shifted `# noqa: C901` up one line


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I've used my lab switches to test this.


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
