### PR TITLE
Add transport options

### DIFF
--- a/scrapli/transport/plugins/asyncssh/transport.py
+++ b/scrapli/transport/plugins/asyncssh/transport.py
@@ -109,9 +109,9 @@ class AsyncsshTransport(AsyncTransport):
             "agent_path": None,
             "config": self.plugin_transport_args.ssh_config_file,
         }
-        
-        if hasattr(self._base_transport_args, "transport_options"):
-            common_args.update(self._base_transport_args.transport_options)
+
+        # Allow passing `transport_options` to asyncssh
+        common_args.update(self._base_transport_args.transport_options)
 
         try:
             self.session = await asyncio.wait_for(

--- a/scrapli/transport/plugins/asyncssh/transport.py
+++ b/scrapli/transport/plugins/asyncssh/transport.py
@@ -109,6 +109,9 @@ class AsyncsshTransport(AsyncTransport):
             "agent_path": None,
             "config": self.plugin_transport_args.ssh_config_file,
         }
+        
+        if hasattr(self._base_transport_args, "transport_options"):
+            common_args.update(self._base_transport_args.transport_options)
 
         try:
             self.session = await asyncio.wait_for(


### PR DESCRIPTION
# Description

This PR allows `transport-options` to be applied to `asyncssh` driver. This enables the ability to add specific options to `asyncssh` such as add legacy encryption and key-exchange algorithms for old network devices.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tested with my lab, using below platform and versions
- HUAWEI_VRP	V200R005C10SPC800
- HUAWEI_VRP	V200R002C50SPC800
- HUAWEI_VRP	V300R019C00SPC300
- CISCO_NXOS	7.0(3)I4(4)
- CISCO_NXOS	9.2(3)
- CISCO_NXOS	9.2(1)
- CISCO_NXOS	9.3(3)
- ARISTA_EOS	4.24.4M

This is my test script (removed private information)
```python
default_device_options = {
    "auth_username": username,
    "auth_password": password,
    "auth_strict_key": False,
    "transport": "asyncssh",
}


device_type_dct = {
    "HUAWEI_VRP": {
        "options": {
            "platform": "huawei_vrp",
            "transport_options": {
                "kex_algs": ["diffie-hellman-group14-sha1", "diffie-hellman-group1-sha1", "diffie-hellman-group-exchange-sha1"],
                "encryption_algs": ["aes256-cbc", "aes192-cbc", "aes256-ctr", "aes192-ctr", "aes128-ctr"],
            },
        },
        "commands": [
            "display current-config",
            "display interface",
        ]
    },
    "ARISTA_EOS": {
        "options": {
            "platform": "arista_eos",
        },
        "commands": [
            "show running-config",
            "show interface | json",
        ]
    },
    "CISCO_NXOS": {
        "options": {
            "platform": "cisco_nxos",
        },
        "commands": [
            "show running-config",
            "show interface | json",
        ]
    },
}


logging.basicConfig(
    filename="scrapli-01.log",
    filemode="w",
    format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
    datefmt='%H:%M:%S',
    # level=logging.INFO,
    level=logging.DEBUG,
)
logger = logging.getLogger(__name__)


class Result:
    def __init__(self, resp=None, error=None):
        self.resp = resp
        self.error = error

    def get_result(self):
        return self.resp, self.error

    def __str__(self):
        return f"{self.resp} / {self.error}"


async def execute_w_timeout(task, timeout):
    try:
        resp = await asyncio.wait_for(task, timeout)
        return Result(resp, None)
    except asyncio.TimeoutError as ex:
        return Result(None, ex)
    except Exception as ex:
        return Result(None, ex)


async def worker(device, device_dct):
    ip, hostname, vendor = device[:3]
    logger.debug(f"Worker {hostname}/{ip}/{vendor} started")

    device_info = device_dct[hostname]
    driver_options = deepcopy(default_device_options)
    driver_options.update(device_type_dct[vendor]["options"])
    command_lst = device_type_dct[vendor]["commands"]

    driver_options["host"] = ip
    driver_options["channel_log"] = f"logs/{hostname}.log"
    if device_info["status"] == STATUS_NOT_STARTED:
        try:
            async with AsyncScrapli(**driver_options) as conn:
                logger.debug(f"Worker {hostname}/{ip}/{vendor} connected")
                device_info["status"] = STATUS_STARTED

                prompt, error = (await execute_w_timeout(conn.get_prompt(), 5)).get_result()
                if error is None:
                    device_info["status"] = STATUS_WORKING

                    actual_hostname = prompt.strip("<[]># $")
                    if actual_hostname in hostname or hostname in actual_hostname:
                        device_info["matched_hostname"] = True
                        for cmd in command_lst:
                            result = await execute_w_timeout(conn.send_command(cmd), 60)
                            if result.error:
                                logger.warning(f"Worker {hostname}/{ip} encountered error - {result.error}")
                                device_info["status"] = STATUS_FAILED
                                break
                            else:
                                device_info["commands"][cmd] = result.resp
                        else:
                            device_info["status"] = STATUS_COMPLETED

                    else:
                        device_info["status"] = STATUS_IGNORED
                        logger.warning(f"Worker {hostname}/{ip} has prompt=[{prompt}] - Not matched. Ignore!")

                else:
                    device_info["status"] = STATUS_FAILED
                    logger.warning(f"Worker {hostname}/{ip} has Exception - {error}. Stop!")
                #
        except Exception as ex:
            device_info["status"] = STATUS_FAILED
            raise (ex)
    else:
        logger.debug(f"Worker {hostname}/{ip}/{vendor} already started. Ignore!")

    logger.warning(f"Worker {hostname}/{ip} ended")


async def run(loop, device_lst, device_dct):
    for device in device_lst:
        ip, hostname, vendor = device[:3]
        if hostname not in device_dct:
            device_dct[hostname] = {
                "status": STATUS_NOT_STARTED,
                "matched_hostname": False,
                "commands": {},
                "session": None,
            }

        task = loop.create_task(
            # execute_w_timeout(
                worker(device, device_dct),
                # 600
            # )
        )
        logger.info(f"Runner created a Worker({device})")

    completed_tasks = []
    timeout = 10
    while len(completed_tasks) < len(device_dct):
        await asyncio.sleep(1)
        for device in device_dct:
            if device not in completed_tasks:
                if device_dct[device]["status"] in [STATUS_FAILED, STATUS_COMPLETED, STATUS_IGNORED]:
                    completed_tasks.append(device)

        if timeout == 0:
            timeout = 10
            active_tasks = set(device_dct) - set(completed_tasks)
            for task in active_tasks:
                print(f"\tPending task - {task}")
        else:
            timeout -= 1
        print(f"Executing {len(completed_tasks)}/{len(device_dct)}")

def main():
    device_lst = [
        ("ip_address1", "real_hostname1", "HUAWEI_VRP"),
        ("ip_address2", "real_hostname2", "HUAWEI_VRP"),
    ]
    print("List of devices")
    for dev in device_lst:
        print(dev)

    scrapli.logging.enable_basic_logging(
        file=True,
        level='debug',
        caller_info=True,
    )
    loop = asyncio.get_event_loop()
    device_dct = {}

    print("STARTED")
    loop.run_until_complete(run(loop, device_lst, device_dct))

    for device, device_info in device_dct.items():
        print("-"*20, device, device_info["status"], "-"*40)
        for cmd, resp in device_info["commands"].items():
            print("----", cmd)
            if resp is not None:
                print("Good", len(resp.result))
            else:
                print("No response")

    print("ENDED")

if __name__ == "__main__":
    main()
```

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
