### PR TITLE
Minor typos, broken links fixed.

### DIFF
--- a/docs/user_guide/advanced_usage.md
+++ b/docs/user_guide/advanced_usage.md
@@ -323,8 +323,8 @@ scrapli is built to be very flexible, including being flexible enough to use dif
   dependencies as it just relies on what is available on the machine running the scrapli script.
 
 In the spirit of being highly flexible, scrapli allows users to swap out this "system" transport with another
- transport mechanism. The other supported transport plugins are `paramiko`, `ssh2-python` and `telnetlib
- `, `paramiko`, `ssh2-python`, and `asynctelnet`. The transport selection can be made  when instantiating the 
+ transport mechanism. The other supported transport plugins are `paramiko`, `ssh2-python`, `telnetlib
+ `, `asyncssh`, and `asynctelnet`. The transport selection can be made  when instantiating the 
 scrapli connection object by passing in `paramiko`, `ssh2`, `telnet`, `asyncssh`, or `asynctelnet` to force  scrapli 
 to use the corresponding transport mechanism. If you are using one of the async transports you must use an async driver!
   

--- a/docs/user_guide/basic_usage.md
+++ b/docs/user_guide/basic_usage.md
@@ -112,7 +112,7 @@ conn.open()
 scrapli does *not* open the connection for you when creating your scrapli connection object in normal operations, you
  must manually call the `open` method prior to sending any commands to the device as shown below.
 
- ```python
+```python
 from scrapli.driver.core import IOSXRDriver
 
 my_device = {
@@ -157,7 +157,7 @@ When using any of the core network drivers (`JunosDriver`, `EOSDriver`, etc.) or
 ` and `send_commands` methods will respectively send a single command or list of commands to the device.
 
 When using the core network drivers, the command(s) will be sent at the `default_desired_privilege_level` level which is
- typically "privilege exec" (or equivalent) privilege level. Please see [Driver Privilege Levels](/user_guide/advanced_usage/#driver-privilege-levels)
+ typically "privilege exec" (or equivalent) privilege level. Please see [Driver Privilege Levels](/scrapli/user_guide/advanced_usage/#driver-privilege-levels)
   in the advanced usage section for more details on privilege levels. As the `GenericDriver` doesn't know or
   care about privilege levels you would need to manually handle acquiring the appropriate privilege level for you
    command yourself if using that driver.
@@ -253,7 +253,7 @@ with IOSXEDriver(**my_device) as conn:
 
 If you need to get into any kind of "special" configuration mode, such as "configure exclusive", "configure private
 ", or "configure session XYZ", you can pass the name of the corresponding privilege level via the `privilege_level
-` argument. Please see the [Driver Privilege Levels](/user_guide/advanced_usage/#driver-privilege-levels) section for more details!
+` argument. Please see the [Driver Privilege Levels](/scrapli/user_guide/advanced_usage/#driver-privilege-levels) section for more details!
 
 Lastly, note that scrapli does *not* exit configuration mode at completion of a "configuration" event -- this is
  because scrapli (with the Network drivers) will automatically acquire `default_desired_privilege_level` before


### PR DESCRIPTION
# Description

Motivation - first 'real' pull request to a project.
Link for 'Driver Privilege Levels' was missing the /scrapli/ directory. Duplicate transport options listed. Python code block was not appearing correctly in the browser (shows up fine in vscode preview and even in github, so maybe related to mkdocs?). I assume it was the extra space in front.


## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

vscode preview. Minor text changes, nothing else to test.


# Checklist:

- [X ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)

