### PR TITLE
Link should have been absolute due to scrapli folder name.

### DIFF
--- a/docs/user_guide/basic_usage.md
+++ b/docs/user_guide/basic_usage.md
@@ -157,7 +157,7 @@ When using any of the core network drivers (`JunosDriver`, `EOSDriver`, etc.) or
 ` and `send_commands` methods will respectively send a single command or list of commands to the device.
 
 When using the core network drivers, the command(s) will be sent at the `default_desired_privilege_level` level which is
- typically "privilege exec" (or equivalent) privilege level. Please see [Driver Privilege Levels](/scrapli/user_guide/advanced_usage/#driver-privilege-levels)
+ typically "privilege exec" (or equivalent) privilege level. Please see [Driver Privilege Levels](https://carlmontanari.github.io/scrapli/user_guide/advanced_usage/#driver-privilege-levels)
   in the advanced usage section for more details on privilege levels. As the `GenericDriver` doesn't know or
   care about privilege levels you would need to manually handle acquiring the appropriate privilege level for you
    command yourself if using that driver.
@@ -253,7 +253,7 @@ with IOSXEDriver(**my_device) as conn:
 
 If you need to get into any kind of "special" configuration mode, such as "configure exclusive", "configure private
 ", or "configure session XYZ", you can pass the name of the corresponding privilege level via the `privilege_level
-` argument. Please see the [Driver Privilege Levels](/scrapli/user_guide/advanced_usage/#driver-privilege-levels) section for more details!
+` argument. Please see the [Driver Privilege Levels](https://carlmontanari.github.io/scrapli/user_guide/advanced_usage/#driver-privilege-levels) section for more details!
 
 Lastly, note that scrapli does *not* exit configuration mode at completion of a "configuration" event -- this is
  because scrapli (with the Network drivers) will automatically acquire `default_desired_privilege_level` before


### PR DESCRIPTION
# Description

Sorry, looks like the relative link fails, I noted other links using # point directly to https/absolute link, should've noticed previously.


## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

only checking the link


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
