### PR TITLE
Feature textfsm template file

### DIFF
--- a/docs/api_docs/helper.md
+++ b/docs/api_docs/helper.md
@@ -30,7 +30,8 @@ scrapli.helper
         <code class="python">
 """scrapli.helper"""
 import importlib
-from io import TextIOWrapper
+import urllib.request
+from io import BytesIO, TextIOWrapper
 from pathlib import Path
 from shutil import get_terminal_size
 from typing import Any, Dict, List, Optional, TextIO, Union
@@ -114,7 +115,7 @@ def textfsm_parse(
     Parse output with TextFSM and ntc-templates, try to return structured output
 
     Args:
-        template: TextIOWrapper or string path to template to use to parse data
+        template: TextIOWrapper or string of URL or filesystem path to template to use to parse data
         output: unstructured output from device to parse
         to_dict: convert textfsm output from list of lists to list of dicts -- basically create dict
             from header and row data so it is easier to read/parse the output
@@ -129,7 +130,17 @@ def textfsm_parse(
     import textfsm  # pylint: disable=C0415
 
     if not isinstance(template, TextIOWrapper):
-        template_file = open(template, encoding="utf-8")  # pylint: disable=R1732
+        if template.startswith("http://") or template.startswith("https://"):
+            with urllib.request.urlopen(template) as response:
+                template_file = TextIOWrapper(
+                    BytesIO(response.read()),
+                    encoding=response.headers.get_content_charset(),
+                )
+        else:
+            template_file = TextIOWrapper(
+                open(template, "rb", encoding="utf-8"),
+                encoding="utf-8",
+            )  # pylint: disable=R1732
     else:
         template_file = template
     re_table = textfsm.TextFSM(template_file)
@@ -401,7 +412,7 @@ Raises:
 Parse output with TextFSM and ntc-templates, try to return structured output
 
 Args:
-    template: TextIOWrapper or string path to template to use to parse data
+    template: TextIOWrapper or string of URL or filesystem path to template to use to parse data
     output: unstructured output from device to parse
     to_dict: convert textfsm output from list of lists to list of dicts -- basically create dict
         from header and row data so it is easier to read/parse the output

--- a/docs/api_docs/response.md
+++ b/docs/api_docs/response.md
@@ -32,7 +32,7 @@ scrapli.response
 from collections import UserList
 from datetime import datetime
 from io import TextIOWrapper
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, TextIO, Union, cast
 
 from scrapli.exceptions import ScrapliCommandFailure
 from scrapli.helper import _textfsm_get_template, genie_parse, textfsm_parse, ttp_parse
@@ -170,13 +170,16 @@ class Response:
         elif all(err not in self.result for err in self.failed_when_contains):
             self.failed = False
 
-    def textfsm_parse_output(self, to_dict: bool = True) -> Union[Dict[str, Any], List[Any]]:
+    def textfsm_parse_output(
+        self, template: Union[str, TextIO, None] = None, to_dict: bool = True
+    ) -> Union[Dict[str, Any], List[Any]]:
         """
         Parse results with textfsm, always return structured data
 
         Returns an empty list if parsing fails!
 
         Args:
+            template: string path to textfsm template or opened textfsm template file
             to_dict: convert textfsm output from list of lists to list of dicts -- basically create
                 dict from header and row data so it is easier to read/parse the output
 
@@ -187,12 +190,16 @@ class Response:
             N/A
 
         """
-        template = _textfsm_get_template(platform=self.textfsm_platform, command=self.channel_input)
-        return (
-            (textfsm_parse(template=template, output=self.result, to_dict=to_dict) or [])
-            if isinstance(template, TextIOWrapper)
-            else []
-        )
+        if template is None:
+            template = _textfsm_get_template(
+                platform=self.textfsm_platform, command=self.channel_input
+            )
+
+        if template is None:
+            return []
+
+        template = cast(Union[str, TextIOWrapper], template)
+        return textfsm_parse(template=template, output=self.result, to_dict=to_dict) or []
 
     def genie_parse_output(self) -> Union[Dict[str, Any], List[Any]]:
         """
@@ -770,13 +777,16 @@ class Response:
         elif all(err not in self.result for err in self.failed_when_contains):
             self.failed = False
 
-    def textfsm_parse_output(self, to_dict: bool = True) -> Union[Dict[str, Any], List[Any]]:
+    def textfsm_parse_output(
+        self, template: Union[str, TextIO, None] = None, to_dict: bool = True
+    ) -> Union[Dict[str, Any], List[Any]]:
         """
         Parse results with textfsm, always return structured data
 
         Returns an empty list if parsing fails!
 
         Args:
+            template: string path to textfsm template or opened textfsm template file
             to_dict: convert textfsm output from list of lists to list of dicts -- basically create
                 dict from header and row data so it is easier to read/parse the output
 
@@ -787,12 +797,16 @@ class Response:
             N/A
 
         """
-        template = _textfsm_get_template(platform=self.textfsm_platform, command=self.channel_input)
-        return (
-            (textfsm_parse(template=template, output=self.result, to_dict=to_dict) or [])
-            if isinstance(template, TextIOWrapper)
-            else []
-        )
+        if template is None:
+            template = _textfsm_get_template(
+                platform=self.textfsm_platform, command=self.channel_input
+            )
+
+        if template is None:
+            return []
+
+        template = cast(Union[str, TextIOWrapper], template)
+        return textfsm_parse(template=template, output=self.result, to_dict=to_dict) or []
 
     def genie_parse_output(self) -> Union[Dict[str, Any], List[Any]]:
         """
@@ -924,7 +938,7 @@ Raises:
     
 
 ##### textfsm_parse_output
-`textfsm_parse_output(self, to_dict: bool = True) ‑> Union[List[Any], Dict[str, Any]]`
+`textfsm_parse_output(self, template: Union[str, TextIO, ForwardRef(None)] = None, to_dict: bool = True) ‑> Union[List[Any], Dict[str, Any]]`
 
 ```text
 Parse results with textfsm, always return structured data
@@ -932,6 +946,7 @@ Parse results with textfsm, always return structured data
 Returns an empty list if parsing fails!
 
 Args:
+    template: string path to textfsm template or opened textfsm template file
     to_dict: convert textfsm output from list of lists to list of dicts -- basically create
         dict from header and row data so it is easier to read/parse the output
 

--- a/docs/user_guide/basic_usage.md
+++ b/docs/user_guide/basic_usage.md
@@ -287,7 +287,7 @@ with IOSXEDriver(**my_device) as conn:
 ```
 
 scrapli also supports passing in templates manually (meaning not using the pip installed ntc-templates directory to
- find templates) if desired. The `scrapli.helper.textfsm_parse` function accepts a string or loaded (TextIOWrapper
+ find templates) if desired. The `textfsm_parse_output` method and `scrapli.helper.textfsm_parse` function both accepts a string or loaded (TextIOWrapper
  ) template and output to parse. This can be useful if you have custom or one off templates or don't want to pip
   install ntc-templates.
   

--- a/scrapli/helper.py
+++ b/scrapli/helper.py
@@ -107,10 +107,7 @@ def textfsm_parse(
                     encoding=response.headers.get_content_charset(),
                 )
         else:
-            template_file = TextIOWrapper(
-                open(template, "rb", encoding="utf-8"),
-                encoding="utf-8",
-            )  # pylint: disable=R1732
+            template_file = TextIOWrapper(open(template, mode="rb"))  # pylint: disable=R1732
     else:
         template_file = template
     re_table = textfsm.TextFSM(template_file)

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -21,6 +21,7 @@ IOS_ARP = """Protocol  Address          Age (min)  Hardware Addr   Type   Interf
 Internet  172.31.254.1            -   0000.0c07.acfe  ARPA   Vlan254
 Internet  172.31.254.2            -   c800.84b2.e9c2  ARPA   Vlan254
 """
+IOS_ARP_NTC_TEMPLATE_URL = "https://raw.githubusercontent.com/networktocode/ntc-templates/master/ntc_templates/templates/cisco_ios_show_ip_arp.textfsm"
 
 
 def test_textfsm_get_template():
@@ -101,6 +102,35 @@ def test_textfsm_parse_string_path(test_data):
     to_dict, expected_output = test_data
     template = _textfsm_get_template("cisco_ios", "show ip arp")
     result = textfsm_parse(template.name, IOS_ARP, to_dict=to_dict)
+    assert isinstance(result, list)
+    assert result[0] == expected_output
+
+
+@pytest.mark.parametrize(
+    "test_data",
+    [
+        (
+            False,
+            ["Internet", "172.31.254.1", "-", "0000.0c07.acfe", "ARPA", "Vlan254"],
+        ),
+        (
+            True,
+            {
+                "protocol": "Internet",
+                "address": "172.31.254.1",
+                "age": "-",
+                "mac": "0000.0c07.acfe",
+                "type": "ARPA",
+                "interface": "Vlan254",
+            },
+        ),
+    ],
+    ids=["to_dict_false", "to_dict_true"],
+)
+def test_textfsm_parse_url_path(test_data):
+    to_dict, expected_output = test_data
+    template = IOS_ARP_NTC_TEMPLATE_URL
+    result = textfsm_parse(template, IOS_ARP, to_dict=to_dict)
     assert isinstance(result, list)
     assert result[0] == expected_output
 

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import pytest
 
 from scrapli.exceptions import ScrapliCommandFailure
+from scrapli.helper import _textfsm_get_template
 from scrapli.response import MultiResponse, Response
 
 
@@ -133,6 +134,18 @@ Internet  172.31.254.2            -   c800.84b2.e9c2  ARPA   Vlan254
 """
     response.record_response(response_bytes)
     assert response.textfsm_parse_output(to_dict=to_dict)[0] == expected_result
+
+
+def test_response_parse_textfsm_string_path():
+    template = _textfsm_get_template("cisco_ios", "show ip arp")
+    response = Response("localhost", channel_input="show ip arp", textfsm_platform="cisco_ios")
+    response_bytes = b"""Protocol  Address          Age (min)  Hardware Addr   Type   Interface
+Internet  172.31.254.1            -   0000.0c07.acfe  ARPA   Vlan254
+Internet  172.31.254.2            -   c800.84b2.e9c2  ARPA   Vlan254
+"""
+    response.record_response(response_bytes)
+    result = response.textfsm_parse_output(template=template)
+    assert result[0]["address"] == "172.31.254.1"
 
 
 def test_response_parse_textfsm_fail():

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -137,7 +137,7 @@ Internet  172.31.254.2            -   c800.84b2.e9c2  ARPA   Vlan254
 
 
 def test_response_parse_textfsm_string_path():
-    template = _textfsm_get_template("cisco_ios", "show ip arp")
+    template = _textfsm_get_template("cisco_ios", "show ip arp").name
     response = Response("localhost", channel_input="show ip arp", textfsm_platform="cisco_ios")
     response_bytes = b"""Protocol  Address          Age (min)  Hardware Addr   Type   Interface
 Internet  172.31.254.1            -   0000.0c07.acfe  ARPA   Vlan254


### PR DESCRIPTION
# Description

This is a PR that is discussed in #214.

Make `textfsm_parse_output` method to accept a manually specified textfsm template path.
Make `scrapli.helper.textfsm_parse` method to accept URLs as a textfsm template path.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I have added some tests in `tests/unit/test_response.py` and `tests/unit/test_helper.py`.


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
