### PR TITLE
handle seeing current priv again after trying to escalate auth

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ Changelog
 - Remove newline anchor in in-channel auth password pattern. Felt like a good/smart idea but Cisco in their infinite 
   wisdom have some awful banner on IOL (CML/VIRL) things that doesn't end with a newline and too many people will 
   hit that.
+- Modified `escalate_priv` methods to check for password prompt and desired prompt patterns *and* the current prompt
+  pattern. There was an issue in scrapligo/containerlab where a cEOS device would not let you auth past enable until
+  it is done "booting" up, and scrapli would just simply timeout as it didn't expect to see the exec prompt again. 
+  Thanks to @hellt for helping track this one down!
 
 
 ## 2022.01.30

--- a/scrapli/driver/network/async_driver.py
+++ b/scrapli/driver/network/async_driver.py
@@ -106,7 +106,10 @@ class AsyncNetworkDriver(AsyncGenericDriver, BaseNetworkDriver):
                         (escalate_priv.escalate, escalate_priv.escalate_prompt, False),
                         (self.auth_secondary, escalate_priv.pattern, True),
                     ],
-                    interaction_complete_patterns=[escalate_priv.pattern],
+                    interaction_complete_patterns=[
+                        self.privilege_levels[escalate_priv.previous_priv].pattern,
+                        escalate_priv.pattern,
+                    ],
                 )
             except ScrapliTimeout as exc:
                 raise ScrapliAuthenticationFailed(

--- a/scrapli/driver/network/sync_driver.py
+++ b/scrapli/driver/network/sync_driver.py
@@ -106,7 +106,10 @@ class NetworkDriver(GenericDriver, BaseNetworkDriver):
                         (escalate_priv.escalate, escalate_priv.escalate_prompt, False),
                         (self.auth_secondary, escalate_priv.pattern, True),
                     ],
-                    interaction_complete_patterns=[escalate_priv.pattern],
+                    interaction_complete_patterns=[
+                        self.privilege_levels[escalate_priv.previous_priv].pattern,
+                        escalate_priv.pattern,
+                    ],
                 )
             except ScrapliTimeout as exc:
                 raise ScrapliAuthenticationFailed(

--- a/tests/unit/driver/network/test_network_async_driver.py
+++ b/tests/unit/driver/network/test_network_async_driver.py
@@ -112,6 +112,68 @@ async def test_acquire_priv_deescalate(monkeypatch, async_network_driver):
     await async_network_driver.acquire_priv(desired_priv="privilege_exec")
 
 
+async def test_acquire_priv_escalate_not_ready_same_priv(monkeypatch, async_network_driver):
+    """
+    This tests to make sure that if the device does something like ceos does like this:
+
+    ```
+    info::ceos::"sending channelInput: enable; stripPrompt: false; eager: false
+    write::ceos::write: enable
+    debug::ceos::read: enable
+    write::ceos::write:
+    debug::ceos::read:
+    debug::ceos::read: % Authorization denied for command 'enable': Default authorization provider rejects all commands
+    debug::ceos::read: ceos>
+    ```
+
+    we gracefully handle returning to the current priv level -- rather than only being okay with
+    seeing a password prompt and/or the *next* pirv level. Thank you @ntdvps/@hellt (Roman) for
+    helping find this issue!
+
+    """
+    _prompt_counter = 0
+
+    async def _get_prompt(cls):
+        nonlocal _prompt_counter
+        if _prompt_counter == 0:
+            prompt = "scrapli>"
+        elif _prompt_counter == 1:
+            prompt = "scrapli>"
+        else:
+            prompt = "scrapli#"
+        _prompt_counter += 1
+        return prompt
+
+    async def __read_until_input(cls, channel_input):
+        return channel_input
+
+    async def __read_until_explicit_prompt(cls, prompts):
+        # we dont really care what we return here, just needs to be bytes. but we *do* care that
+        # in this case we are receiving *three* prompt patterns -- the password pattern, the
+        # escalate priv pattern, and the *current* priv pattern.
+        assert len(prompts) == 3
+
+        return b"scrapli>"
+
+    def _write(cls, channel_input, **kwargs):
+        return
+
+    monkeypatch.setattr("scrapli.channel.async_channel.AsyncChannel.get_prompt", _get_prompt)
+    monkeypatch.setattr(
+        "scrapli.channel.async_channel.AsyncChannel._read_until_input", __read_until_input
+    )
+    monkeypatch.setattr(
+        "scrapli.channel.async_channel.AsyncChannel._read_until_explicit_prompt",
+        __read_until_explicit_prompt,
+    )
+    monkeypatch.setattr(
+        "scrapli.transport.plugins.asynctelnet.transport.AsynctelnetTransport.write", _write
+    )
+
+    async_network_driver._current_priv_level = async_network_driver.privilege_levels["exec"]
+    await async_network_driver.acquire_priv(desired_priv="privilege_exec")
+
+
 async def test_acquire_priv_failure(monkeypatch, async_network_driver):
     async def _get_prompt(cls):
         return "scrapli(config)#"

--- a/tests/unit/driver/network/test_network_sync_driver.py
+++ b/tests/unit/driver/network/test_network_sync_driver.py
@@ -1,6 +1,6 @@
 import pytest
 
-from scrapli.exceptions import ScrapliPrivilegeError
+from scrapli.exceptions import ScrapliPrivilegeError, ScrapliTimeout
 
 
 def test_escalate(monkeypatch, sync_network_driver):
@@ -98,6 +98,66 @@ def test_acquire_priv_deescalate(monkeypatch, sync_network_driver):
     monkeypatch.setattr("scrapli.channel.sync_channel.Channel.send_input", _send_input)
 
     sync_network_driver._current_priv_level = sync_network_driver.privilege_levels["configuration"]
+    sync_network_driver.acquire_priv(desired_priv="privilege_exec")
+
+
+def test_acquire_priv_escalate_not_ready_same_priv(monkeypatch, sync_network_driver):
+    """
+    This tests to make sure that if the device does something like ceos does like this:
+
+    ```
+    info::ceos::"sending channelInput: enable; stripPrompt: false; eager: false
+    write::ceos::write: enable
+    debug::ceos::read: enable
+    write::ceos::write:
+    debug::ceos::read:
+    debug::ceos::read: % Authorization denied for command 'enable': Default authorization provider rejects all commands
+    debug::ceos::read: ceos>
+    ```
+
+    we gracefully handle returning to the current priv level -- rather than only being okay with
+    seeing a password prompt and/or the *next* pirv level. Thank you @ntdvps/@hellt (Roman) for
+    helping find this issue!
+
+    """
+    _prompt_counter = 0
+
+    def _get_prompt(cls):
+        nonlocal _prompt_counter
+        if _prompt_counter == 0:
+            prompt = "scrapli>"
+        elif _prompt_counter == 1:
+            prompt = "scrapli>"
+        else:
+            prompt = "scrapli#"
+        _prompt_counter += 1
+        return prompt
+
+    def __read_until_input(cls, channel_input):
+        return channel_input
+
+    def __read_until_explicit_prompt(cls, prompts):
+        # we dont really care what we return here, just needs to be bytes. but we *do* care that
+        # in this case we are receiving *three* prompt patterns -- the password pattern, the
+        # escalate priv pattern, and the *current* priv pattern.
+        assert len(prompts) == 3
+
+        return b"scrapli>"
+
+    def _write(cls, channel_input, **kwargs):
+        return
+
+    monkeypatch.setattr("scrapli.channel.sync_channel.Channel.get_prompt", _get_prompt)
+    monkeypatch.setattr(
+        "scrapli.channel.sync_channel.Channel._read_until_input", __read_until_input
+    )
+    monkeypatch.setattr(
+        "scrapli.channel.sync_channel.Channel._read_until_explicit_prompt",
+        __read_until_explicit_prompt,
+    )
+    monkeypatch.setattr("scrapli.transport.plugins.system.transport.SystemTransport.write", _write)
+
+    sync_network_driver._current_priv_level = sync_network_driver.privilege_levels["exec"]
     sync_network_driver.acquire_priv(desired_priv="privilege_exec")
 
 


### PR DESCRIPTION
dont timeout when devices are not ready to escalate auth. cropped up in scrapligo/boxen when connecting to device that just fired up -- sending "enable" caused the device to say something like "cant do that yet, not ready" and kicked back to the exec prompt. scrapligo died at that point as it was looking for either the password prompt or the privilege exec prompt. this fixes that to also accept seeing the exec (or w/e the current prompt is) prompt one more time. this is fine because before moving on we validate the current prompt/priv level is what we want (before breaking out of the escalate auth loop).