### PR TITLE
Let mypy infer the correct context vars types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ venv.bak/
 # pycharm
 .idea
 
+# vscode
+.vscode/
+
 # mypy
 .mypy_cache/
 .dmypy.json

--- a/scrapli/driver/base/async_driver.py
+++ b/scrapli/driver/base/async_driver.py
@@ -7,8 +7,7 @@ from scrapli.driver.base.base_driver import BaseDriver
 from scrapli.exceptions import ScrapliValueError
 from scrapli.transport import ASYNCIO_TRANSPORTS
 
-
-_T = TypeVar("_T")
+_T = TypeVar("_T", bound="AsyncDriver")
 
 
 class AsyncDriver(BaseDriver):

--- a/scrapli/driver/base/async_driver.py
+++ b/scrapli/driver/base/async_driver.py
@@ -1,11 +1,14 @@
 """scrapli.driver.base.async_driver"""
 from types import TracebackType
-from typing import Any, Optional, Type
+from typing import Any, Optional, Type, TypeVar
 
 from scrapli.channel import AsyncChannel
 from scrapli.driver.base.base_driver import BaseDriver
 from scrapli.exceptions import ScrapliValueError
 from scrapli.transport import ASYNCIO_TRANSPORTS
+
+
+_T = TypeVar("_T")
 
 
 class AsyncDriver(BaseDriver):
@@ -23,7 +26,7 @@ class AsyncDriver(BaseDriver):
             base_channel_args=self._base_channel_args,
         )
 
-    async def __aenter__(self):
+    async def __aenter__(self: _T) -> _T:
         """
         Enter method for context manager
 

--- a/scrapli/driver/base/async_driver.py
+++ b/scrapli/driver/base/async_driver.py
@@ -23,7 +23,7 @@ class AsyncDriver(BaseDriver):
             base_channel_args=self._base_channel_args,
         )
 
-    async def __aenter__(self) -> "AsyncDriver":
+    async def __aenter__(self):
         """
         Enter method for context manager
 
@@ -31,7 +31,7 @@ class AsyncDriver(BaseDriver):
             N/A
 
         Returns:
-            AsyncDriver: opened AsyncDriver object
+            AsyncDriver: a concrete implementation of the opened AsyncDriver object
 
         Raises:
             N/A

--- a/scrapli/driver/base/sync_driver.py
+++ b/scrapli/driver/base/sync_driver.py
@@ -1,11 +1,14 @@
 """scrapli.driver.base.sync_driver"""
 from types import TracebackType
-from typing import Any, Optional, Type
+from typing import Any, Optional, Type, TypeVar
 
 from scrapli.channel import Channel
 from scrapli.driver.base.base_driver import BaseDriver
 from scrapli.exceptions import ScrapliValueError
 from scrapli.transport import ASYNCIO_TRANSPORTS
+
+
+_T = TypeVar("_T")
 
 
 class Driver(BaseDriver):
@@ -23,7 +26,7 @@ class Driver(BaseDriver):
             base_channel_args=self._base_channel_args,
         )
 
-    def __enter__(self):
+    def __enter__(self: _T) -> _T:
         """
         Enter method for context manager
 

--- a/scrapli/driver/base/sync_driver.py
+++ b/scrapli/driver/base/sync_driver.py
@@ -7,8 +7,7 @@ from scrapli.driver.base.base_driver import BaseDriver
 from scrapli.exceptions import ScrapliValueError
 from scrapli.transport import ASYNCIO_TRANSPORTS
 
-
-_T = TypeVar("_T")
+_T = TypeVar("_T", bound="Driver")
 
 
 class Driver(BaseDriver):

--- a/scrapli/driver/base/sync_driver.py
+++ b/scrapli/driver/base/sync_driver.py
@@ -23,7 +23,7 @@ class Driver(BaseDriver):
             base_channel_args=self._base_channel_args,
         )
 
-    def __enter__(self) -> "Driver":
+    def __enter__(self):
         """
         Enter method for context manager
 
@@ -31,7 +31,7 @@ class Driver(BaseDriver):
             N/A
 
         Returns:
-            Driver: opened Driver object
+            Driver: a concrete implementation of the opened Driver object
 
         Raises:
             N/A


### PR DESCRIPTION
# Description

Hi there! Just a little problem related to mypy and type checking.
You use the reinterpret cast in `__new__` method (it's not quite good, but not an error though), hence in the next code the device object's type is inferred as `Scrapli`.
```
from scrapli import Scrapli
def test_():
    device = Scrapli(**{})
    device.open()
    device.send_command("?")
``` 
But in the next example the `device` type is inferred as a `Driver`, cause this is the ancestor where an  `__enter__` method is
declared in and the return value is annotated as `"Driver"`
```
from scrapli import Scraply
def test_():
    with Scraply(**{}) as device:
        device.send_command("?")
```
The problem is that neither `Driver` nor `BaseDriver` declares not `send_command` method, hence the above code breaks the rules.
Letting mypy do its job with no additional hints fixes it.

All the same is for the asynchronous versions of the drivers. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Before:
![image](https://user-images.githubusercontent.com/25843797/174264965-740984f9-478d-4ad6-9819-2471e9443813.png)

After:
![image](https://user-images.githubusercontent.com/25843797/174265451-b474d3d6-d1ef-4331-a810-9e6c8cd77c31.png)

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
