### PR TITLE
Fix sync telnet transport

### DIFF
--- a/scrapli/transport/plugins/asynctelnet/transport.py
+++ b/scrapli/transport/plugins/asynctelnet/transport.py
@@ -29,7 +29,12 @@ class AsynctelnetTransport(AsyncTransport):
         self.stdout: Optional[asyncio.StreamReader] = None
         self.stdin: Optional[asyncio.StreamWriter] = None
 
-        self._initial_buf = b""
+        self._eof = False
+        self._raw_buf = b""
+        self._cooked_buf = b""
+
+        self._control_char_sent_counter = 0
+        self._control_char_sent_limit = 10
 
     def _handle_control_chars_response(self, control_buf: bytes, c: bytes) -> bytes:
         """
@@ -56,7 +61,7 @@ class AsynctelnetTransport(AsyncTransport):
             if c != IAC:
                 # add whatever character we read to the "normal" output buf so it gets sent off
                 # to the auth method later (username/show prompts may show up here)
-                self._initial_buf += c
+                self._cooked_buf += c
             else:
                 # we got a control character, put it into the control_buf
                 control_buf += c
@@ -88,7 +93,7 @@ class AsynctelnetTransport(AsyncTransport):
 
         return control_buf
 
-    async def _handle_control_chars(self) -> None:
+    def _handle_control_chars(self) -> None:
         """
         Handle control characters -- nearly identical to CPython telnetlib
 
@@ -115,21 +120,11 @@ class AsynctelnetTransport(AsyncTransport):
         # we are working on responding to
         control_buf = b""
 
-        # initial read timeout for control characters can be 1/4 of socket timeout, after reading a
-        # single byte we crank it way down; the next value used to be 0.1 but this was causing some
-        # issues for folks that had devices behaving very slowly... so hopefully 1/10 is a
-        # reasonable value for the follow up char read timeout... of course we will return early if
-        # we do get a char in the buffer so it should be all good!
-        char_read_timeout = self._base_transport_args.timeout_socket / 4
+        while self._raw_buf:
+            c, self._raw_buf = self._raw_buf[:1], self._raw_buf[1:]
+            if not c:
+                raise ScrapliConnectionNotOpened("server returned EOF, connection not opened")
 
-        while True:
-            try:
-                c = await asyncio.wait_for(self.stdout.read(1), timeout=char_read_timeout)
-                if not c:
-                    raise ScrapliConnectionNotOpened("server returned EOF, connection not opened")
-            except asyncio.TimeoutError:
-                return
-            char_read_timeout = self._base_transport_args.timeout_socket / 10
             control_buf = self._handle_control_chars_response(control_buf=control_buf, c=c)
 
     async def open(self) -> None:
@@ -161,8 +156,6 @@ class AsynctelnetTransport(AsyncTransport):
             self.logger.critical(msg)
             raise ScrapliAuthenticationFailed(msg) from exc
 
-        await self._handle_control_chars()
-
         self._post_open_closing_log(closing=False)
 
     def close(self) -> None:
@@ -188,29 +181,39 @@ class AsynctelnetTransport(AsyncTransport):
             return False
         return not self.stdout.at_eof()
 
+    async def _read(self, n: int = 65535) -> None:
+        if not self.stdout:
+            raise ScrapliConnectionNotOpened
+
+        if not self._raw_buf:
+            try:
+                buf = await self.stdout.read(n)
+                self._eof = not buf
+                if self._control_char_sent_counter < self._control_char_sent_limit:
+                    self._raw_buf += buf
+                else:
+                    self._cooked_buf += buf
+            except EOFError as exc:
+                raise ScrapliConnectionError(
+                    "encountered EOF reading from transport; typically means the device closed the "
+                    "connection"
+                ) from exc
+
     @timeout_wrapper
     async def read(self) -> bytes:
         if not self.stdout:
             raise ScrapliConnectionNotOpened
 
-        if self._initial_buf:
-            buf = self._initial_buf
-            self._initial_buf = b""
-            return buf
+        if self._control_char_sent_counter < self._control_char_sent_limit:
+            self._handle_control_chars()
 
-        try:
-            buf = await self.stdout.read(65535)
-            # nxos at least sends "binary transmission" control char, but seems to not (afaik?)
-            # actually advertise it during the control protocol exchange, causing us to not be able
-            # to "know" that it is in binary transmit mode until later... so we will just always
-            # strip this option (b"\x00") out of the buffered data...
-            buf = buf.replace(b"\x00", b"")
-        except EOFError as exc:
-            raise ScrapliConnectionError(
-                "encountered EOF reading from transport; typically means the device closed the "
-                "connection"
-            ) from exc
+        while not self._cooked_buf and not self._eof:
+            await self._read()
+            if self._control_char_sent_counter < self._control_char_sent_limit:
+                self._handle_control_chars()
 
+        buf = self._cooked_buf
+        self._cooked_buf = b""
         return buf
 
     def write(self, channel_input: bytes) -> None:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -50,6 +50,9 @@ def async_transport(request):
 
 @pytest.fixture(scope="class")
 def conn(test_devices_dict, device_type, transport):
+    if device_type == "cisco_nxos" and transport in TELNET_TRANSPORTS:
+        pytest.skip("skipping telnet for nxos hosts")
+
     device = test_devices_dict[device_type].copy()
     driver = device.pop("driver")
     device.pop("base_config")
@@ -189,7 +192,7 @@ def eos_conn(test_devices_dict, transport):
 @pytest.fixture(scope="class")
 def nxos_conn(test_devices_dict, transport):
     if transport in TELNET_TRANSPORTS:
-        pytest.skip("skipping telnet for linux hosts")
+        pytest.skip("skipping telnet for nxos hosts")
 
     device = test_devices_dict["cisco_nxos"].copy()
     driver = device.pop("driver")

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -188,6 +188,9 @@ def eos_conn(test_devices_dict, transport):
 
 @pytest.fixture(scope="class")
 def nxos_conn(test_devices_dict, transport):
+    if transport in TELNET_TRANSPORTS:
+        pytest.skip("skipping telnet for linux hosts")
+
     device = test_devices_dict["cisco_nxos"].copy()
     driver = device.pop("driver")
     device.pop("base_config")

--- a/tests/functional/test_drivers_network.py
+++ b/tests/functional/test_drivers_network.py
@@ -227,6 +227,9 @@ class TestNetworkDevice:
 
 
 def test_context_manager(test_devices_dict, device_type, transport):
+    if device_type == "cisco_nxos" and "telnet" in transport:
+        pytest.skip("skipping telnet for nxos hosts")
+
     device = test_devices_dict[device_type].copy()
     driver = device.pop("driver")
     device.pop("base_config")


### PR DESCRIPTION
# Description
After upgrading scrapli to 2022.07.30, the telnet transport always gets a timeout error.
Refer to the issue #252 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
 list any relevant details for your test configuration


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes