### PR TITLE
Fix greedy read

### DIFF
--- a/scrapli/channel/sync_channel.py
+++ b/scrapli/channel/sync_channel.py
@@ -259,10 +259,12 @@ class Channel(BaseChannel):
                 break
             if any((channel_output in search_buf for channel_output in channel_outputs)):
                 break
-            if m := re.search(pattern=regex_channel_outputs_pattern, string=search_buf) is not None:
+            m = re.search(pattern=regex_channel_outputs_pattern, string=search_buf)
+            if m is not None:
                 match_end = m.end()
                 break
-            if m := re.search(pattern=search_pattern, string=search_buf) is not None:
+            m = re.search(pattern=search_pattern, string=search_buf)
+            if m is not None:
                 match_end = m.end()
                 break
 
@@ -337,10 +339,11 @@ class Channel(BaseChannel):
                     self.write(channel_input=auth_private_key_passphrase, redacted=True)
                     self.send_return()
 
-                if m := re.search(
+                m = re.search(
                     pattern=prompt_pattern,
                     string=authenticate_buf,
-                ) is not None:
+                )
+                if m is not None:
                     self._read_tail = authenticate_buf[m.end(): ]
                     return
 

--- a/tests/unit/channel/test_sync_channel.py
+++ b/tests/unit/channel/test_sync_channel.py
@@ -59,7 +59,7 @@ def test_channel_read(fs_, caplog, monkeypatch, sync_transport_no_abc):
     # assert the log output/level as expected; skip the first log message that will be about
     # channel_log being on
     log_record = caplog.records[1]
-    assert "read: b'read_data'" == log_record.msg
+    assert "read: b'read_data\\r'" == log_record.msg
     assert logging.DEBUG == log_record.levelno
 
     # assert channel log output as expected
@@ -69,7 +69,7 @@ def test_channel_read(fs_, caplog, monkeypatch, sync_transport_no_abc):
 
 
 def test_channel_read_until_input(monkeypatch, sync_channel):
-    expected_read_output = b"read_data\nthisismyinput"
+    expected_read_output = b"read_data thisismyinput"
     _read_counter = 0
 
     def _read(cls):


### PR DESCRIPTION
# Description

Proposed fix for issue https://github.com/scrapli/scrapli_netconf/issues/122 (more details in the issue).

TLDR; scrapli was consuming too much input, which could lead to chunks of the response being discarded.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on Cisco IOS-XR and Juniper Junos-EVO lab devices.
Ran unit test.

# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
