### PR TITLE
ansii esq seq \x1bE support

### DIFF
--- a/scrapli/channel/base_channel.py
+++ b/scrapli/channel/base_channel.py
@@ -10,7 +10,7 @@ from scrapli.exceptions import ScrapliAuthenticationFailed, ScrapliTypeError, Sc
 from scrapli.logging import get_instance_logger
 from scrapli.transport.base import AsyncTransport, Transport
 
-ANSI_ESCAPE_PATTERN = re.compile(rb"\x1b(\[.*?[@-~]|\].*?(\x07|\x1b\\))")
+ANSI_ESCAPE_PATTERN = re.compile(rb"\x1b(\[.*?[@-~]|\].*?(\x07|\x1b\\)|E)")
 
 
 @dataclass()

--- a/tests/unit/channel/test_base_channel.py
+++ b/tests/unit/channel/test_base_channel.py
@@ -285,6 +285,15 @@ def test_process_output(base_channel):
     ),
 )
 def test_strip_ansi(base_channel, buf: bytes, expected: bytes):
+    """
+    See PR 265 for some info about the "x1bE" part :) -> https://github.com/carlmontanari/scrapli/pull/265
+
+    From: https://stackoverflow.com/questions/15011478/ansi-questions-x1b25h-and-x1be
+
+    These are ANSI escape sequences (also known as VT100 codes) are an early standardisation of control codes pre-dating ASCII.
+
+    The escape sequence \x1BE, or Esc+E, is NEL or "Next line", and is used on older terminals and mainframes to denote CR+LF, or \r\n.
+    """
     actual_strip_ansi_output = base_channel._strip_ansi(buf=buf)
     assert actual_strip_ansi_output == expected
 

--- a/tests/unit/channel/test_base_channel.py
+++ b/tests/unit/channel/test_base_channel.py
@@ -271,11 +271,22 @@ def test_process_output(base_channel):
     assert actual_processed_buf == b"linewithtrailingspace\nsomethingelse"
 
 
-def test_strip_ansi(base_channel):
-    actual_strip_ansi_output = base_channel._strip_ansi(
-        buf=b"[admin@CoolDevice.Sea1: \x1b[1m/\x1b[0;0m]$"
-    )
-    assert actual_strip_ansi_output == b"[admin@CoolDevice.Sea1: /]$"
+@pytest.mark.parametrize(
+    "buf, expected",
+    (
+        (
+            b"[admin@CoolDevice.Sea1: \x1b[1m/\x1b[0;0m]$",
+            b"[admin@CoolDevice.Sea1: /]$",
+        ),
+        (
+            b"VeryLong\x1bECommand",
+            b"VeryLongCommand",
+        ),
+    ),
+)
+def test_strip_ansi(base_channel, buf: bytes, expected: bytes):
+    actual_strip_ansi_output = base_channel._strip_ansi(buf=buf)
+    assert actual_strip_ansi_output == expected
 
 
 def test_pre_send_input_exception(base_channel):


### PR DESCRIPTION
# Description

Hello,
Normal SSH exchange that is supported by scrapli is the next:

![image](https://user-images.githubusercontent.com/25843797/196971647-ea09ea70-eef6-40e8-96d5-6332b0a6012c.png)

I'm trying to manage [SONiC](https://sonic-net.github.io/SONiC/) device I encounter the next problem.
When the very long command is entered SONiC's shell echoes it with an extra ANSII code line feed symbol `\x1bE` this like:

![image](https://user-images.githubusercontent.com/25843797/196972008-bcb1f609-4ce9-4df5-910d-517a61f0b04f.png)

scrapli doesn't handle this situation :(

I've found out that you handle ANSII escape symbols almost all of them but this weird oldschool line feed, hence I edited the REGEX.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unfortunately I could not run the unit test suite under Windows or even under Ubuntu cause it requires a number of IP addresses to be accessible.
That's why I've just edited your test the way it must edited.
It's interesting that I was failed to run the only test_strip_ansi test. I didn't get why. The next command acts as I have never changed anything (but I have).
```sh 
py.test -s -v tests/unit/channel/test_base_channel.py -k test_strip_ansi
```
When run this way it literally doesn't see my changes. I couldn't even get a printed message from the method under test. May be I just became nuts or didn't spot smth in unittest machinery :) Anyway...
To make sure everything is OK I've made the same test this way:
```python
ANSI_ESCAPE_PATTERN = re.compile(rb"\x1b(\[.*?[@-~]|\].*?(\x07|\x1b\\)|E)")  # Note my version

def _strip_ansi(buf: bytes) -> bytes:
    return re.sub(pattern=ANSI_ESCAPE_PATTERN, repl=b"", string=buf)

@pytest.mark.parametrize(
    "buf, expected",
    (
        (
            b"[admin@CoolDevice.Sea1: \x1b[1m/\x1b[0;0m]$",
            b"[admin@CoolDevice.Sea1: /]$",
        ),
        (
            b"VeryLong\x1bECommand",
            b"VeryLongCommand",
        ),
    ),
)
def test_strip_ansi(buf: bytes, expected: bytes):
    actual_strip_ansi_output = _strip_ansi(buf=buf)
    assert actual_strip_ansi_output == expected
```
... and everything is just ok as expected! :)
I also checked that scrapli still works as it were with my project after these changes.

# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
