### PR TITLE
Transport plugin asyncssh

### DIFF
--- a/scrapli/transport/plugins/asyncssh/transport.py
+++ b/scrapli/transport/plugins/asyncssh/transport.py
@@ -155,14 +155,16 @@ class AsyncsshTransport(AsyncTransport):
             self._verify_key()
 
         # we already fetched host/port/user from the user input and/or the ssh config file, so we
-        # want to use those explicitly. likewise we pass config file we already found. 
-        # We do not set agent explicitly since asyncssh picks up the agent socket from env
-        # if it is not provided, but doesn't use it at all in case if None explicitly provided 
+        # want to use those explicitly. likewise we pass config file we already found. set known
+        # hosts and agent to None so we can not have an agent and deal w/ known hosts ourselves.
+        # to use ssh-agent either empty tuple (to pick up ssh-agent socket from SSH_AUTH_SOCK) or
+        # explicit path to ssh-agent socket should be provided as part of transport_options
         common_args = {
             "host": self._base_transport_args.host,
             "port": self._base_transport_args.port,
             "username": self.plugin_transport_args.auth_username,
             "known_hosts": None,
+            "agent_path": None,
             "config": self.plugin_transport_args.ssh_config_file,
         }
 

--- a/scrapli/transport/plugins/asyncssh/transport.py
+++ b/scrapli/transport/plugins/asyncssh/transport.py
@@ -155,14 +155,14 @@ class AsyncsshTransport(AsyncTransport):
             self._verify_key()
 
         # we already fetched host/port/user from the user input and/or the ssh config file, so we
-        # want to use those explicitly. likewise we pass config file we already found. set known
-        # hosts and agent to None so we can not have an agent and deal w/ known hosts ourselves
+        # want to use those explicitly. likewise we pass config file we already found. 
+        # We do not set agent explicitly since asyncssh picks up the agent socket from env
+        # if it is not provided, but doesn't use it at all in case if None explicitly provided 
         common_args = {
             "host": self._base_transport_args.host,
             "port": self._base_transport_args.port,
             "username": self.plugin_transport_args.auth_username,
             "known_hosts": None,
-            "agent_path": None,
             "config": self.plugin_transport_args.ssh_config_file,
         }
 

--- a/scrapli/transport/plugins/asyncssh/transport.py
+++ b/scrapli/transport/plugins/asyncssh/transport.py
@@ -51,11 +51,7 @@ class AsyncsshTransport(AsyncTransport):
         This transport supports some additional `transport_options` to control behavior --
         `asyncssh` is a dictionary that contains options that are passed directly to asyncssh during
         connection creation, you can find the SSH Client options of asyncssh here:
-        https://asyncssh.readthedocs.io/en/latest/api.html#sshclientconnectionoptions. In addition
-        to the asyncssh options, you can pass `"ssh_agent": True` to enable asyncssh's default ssh
-        agent handling. For some more information on that please see:
-        https://github.com/carlmontanari/scrapli/issues/268 and
-        https://github.com/carlmontanari/scrapli/pull/266
+        https://asyncssh.readthedocs.io/en/latest/api.html#sshclientconnectionoptions.
 
         Below is an example of passing in options to modify kex and encryption algorithms
 
@@ -162,8 +158,10 @@ class AsyncsshTransport(AsyncTransport):
         # we already fetched host/port/user from the user input and/or the ssh config file, so we
         # want to use those explicitly. likewise we pass config file we already found. set known
         # hosts and agent to None so we can not have an agent and deal w/ known hosts ourselves.
-        # to use ssh-agent either empty tuple (to pick up ssh-agent socket from SSH_AUTH_SOCK) or
-        # explicit path to ssh-agent socket should be provided as part of transport_options
+        # to use ssh-agent either pass an empty tuple (to pick up ssh-agent socket from
+        # SSH_AUTH_SOCK), or pass an explicit path to ssh-agent socket should be provided as part
+        # of transport_options -- in either case these get merged into the dict *after* we set the
+        # default value of `None`, so users options override our defaults.
 
         common_args: Dict[str, Any] = {
             "host": self._base_transport_args.host,


### PR DESCRIPTION
1. Fixed issue with dublicated argumnets in asyncssh transport plugin. In case if preferred authentication order (preferred_auth) is provided as part of transport options, asyncssh transport plugin got exception:
`exceptions.ConnectionException: Something unexpected happens and the connection has been failed. Details asyncssh.connection.connect() got multiple values for keyword argument 'preferred_auth'`
Fix has been suggested in the PR
2. Small suggestion do not to set agent_path = None in asyncssh transport plugin. Asyncssh uses ssh agent from OS env vars by default and doesn't use at all in case if agent_path set None.