### PR TITLE
Add "admin_privilege_exec", "admin_configuration", "admin_configuration_exclusive" privilege for IOSXRDriver

### DIFF
--- a/scrapli/driver/core/cisco_iosxr/base_driver.py
+++ b/scrapli/driver/core/cisco_iosxr/base_driver.py
@@ -13,6 +13,17 @@ PRIVS = {
             escalate_prompt="",
         )
     ),
+    "admin_privilege_exec": (
+        PrivilegeLevel(
+            pattern=r"^[\w.\-@/:]{1,63}\(admin\)#\s?$",
+            name="admin_privilege_exec",
+            previous_priv="privilege_exec",
+            deescalate="exit",
+            escalate="admin",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
     "configuration": (
         PrivilegeLevel(
             pattern=r"^[\w.\-@/:]{1,63}\(config[\w.\-@/:]{0,32}\)#\s?$",
@@ -31,6 +42,28 @@ PRIVS = {
             previous_priv="privilege_exec",
             deescalate="end",
             escalate="configure exclusive",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "admin_configuration": (
+        PrivilegeLevel(
+            pattern=r"^[\w.\-@/:]{1,63}\(admin-config[\w.\-@/:]{0,32}\)#\s?$",
+            name="admin_configuration",
+            previous_priv="privilege_exec",
+            deescalate="end",
+            escalate="admin configure terminal",
+            escalate_auth=False,
+            escalate_prompt="",
+        )
+    ),
+    "admin_configuration_exclusive": (
+        PrivilegeLevel(
+            pattern=r"^[\w.\-@/:]{1,63}\(admin-config[\w.\-@/:]{0,32}\)#\s?$",
+            name="admin_configuration_exclusive",
+            previous_priv="privilege_exec",
+            deescalate="end",
+            escalate="admin configure exclusive",
             escalate_auth=False,
             escalate_prompt="",
         )

--- a/tests/functional/test_cisco_iosxr.py
+++ b/tests/functional/test_cisco_iosxr.py
@@ -7,14 +7,16 @@ def test_configuration_exclusive(iosxr_conn):
     # last character should be an asterisk indicating configuration is locked
     assert result[0].result[-1:] == "*"
 
+
 def test_admin_privilege_exec(iosxr_conn):
     iosxr_conn.acquire_priv("admin_privilege_exec")
     current_prompt = iosxr_conn.get_prompt()
     iosxr_conn.close()
-    assert current_prompt.endswith('(admin)#')
+    assert current_prompt.endswith("(admin)#")
+
 
 def test_admin_configuration(iosxr_conn):
     iosxr_conn.acquire_priv("admin_configuration")
     current_prompt = iosxr_conn.get_prompt()
     iosxr_conn.close()
-    assert current_prompt.endswith('(admin-config)#')
+    assert current_prompt.endswith("(admin-config)#")

--- a/tests/functional/test_cisco_iosxr.py
+++ b/tests/functional/test_cisco_iosxr.py
@@ -6,3 +6,15 @@ def test_configuration_exclusive(iosxr_conn):
     iosxr_conn.close()
     # last character should be an asterisk indicating configuration is locked
     assert result[0].result[-1:] == "*"
+
+def test_admin_privilege_exec(iosxr_conn):
+    iosxr_conn.acquire_priv("admin_privilege_exec")
+    current_prompt = iosxr_conn.get_prompt()
+    iosxr_conn.close()
+    assert current_prompt.endswith('(admin)#')
+
+def test_admin_configuration(iosxr_conn):
+    iosxr_conn.acquire_priv("admin_configuration")
+    current_prompt = iosxr_conn.get_prompt()
+    iosxr_conn.close()
+    assert current_prompt.endswith('(admin-config)#')

--- a/tests/unit/driver/core/cisco_iosxr/test_cisco_iosxr_base_driver.py
+++ b/tests/unit/driver/core/cisco_iosxr/test_cisco_iosxr_base_driver.py
@@ -11,8 +11,18 @@ from scrapli.driver.core.cisco_iosxr.base_driver import PRIVS
         ("privilege_exec", r"RP/0/RP0/CPU0:ios#"),
         ("configuration", r"RP/0/RP0/CPU0:ios(config)#"),
         ("configuration", r"RP/0/RP0/CPU0:i_o_s(config)#"),
+        ("admin_privilege_exec", r"RP/0/RP0/CPU0:ios(admin)#"),
+        ("admin_configuration", r"RP/0/RP0/CPU0:ios(admin-config)#"),
+        ("admin_configuration", r"RP/0/RP0/CPU0:i_o_s(admin-config)#"),
     ],
-    ids=["privilege_exec", "configuration", "privilege_exec_underscore"],
+    ids=[
+        "privilege_exec",
+        "configuration",
+        "privilege_exec_underscore",
+        "admin_privilege_exec",
+        "admin_configuration",
+        "admin_privilege_exec_underscore",
+    ],
 )
 def test_prompt_patterns(priv_pattern, sync_iosxr_driver):
     priv_level_name = priv_pattern[0]
@@ -22,7 +32,7 @@ def test_prompt_patterns(priv_pattern, sync_iosxr_driver):
     assert match
 
     current_priv_guesses = sync_iosxr_driver._determine_current_priv(current_prompt=prompt)
-    if priv_level_name == "configuration":
+    if priv_level_name in ["configuration", "admin_configuration"]:
         # config and config exclusive are same prompt so cant tell them apart and thus we return
         # a list of possible priv levels
         assert len(current_priv_guesses) == 2


### PR DESCRIPTION
# Description

Cisco IOS XR has an [admin mode](https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r4-1/getting_started/configuration/guide/gs41crs/gs41cnov.html#wp1349013
) to manages system resources. I added "admin_privilege_exec", "admin_configuration", "admin_configuration_exclusive" priviledge level to allow managing system resources.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on my lab environment.

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
