### PR TITLE
method _on_post_init()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## 2023.07.30 (in development)
+
+- Expand channel auth patterns to include "no matching host key"
+
+
 ## 2023.01.30
 
 - Expanded ANSII escape sequence handling in #265 thanks to @erwinkinn

--- a/docs/user_guide/advanced_usage.md
+++ b/docs/user_guide/advanced_usage.md
@@ -3,12 +3,10 @@
 
 ## All Driver Arguments
 
-The basic usage section outlined the most commonly used driver arguments, please see the following pages to see all 
-supported driver arguments:
+The basic usage section outlined the most commonly used driver arguments, please see the following page to see all 
+supported base driver arguments:
 
-- [Base `Driver` Arguments](https://carlmontanari.github.io/scrapli/api_docs/driver/base_driver/) 
-- [`GenericDriver` Arguments](https://carlmontanari.github.io/scrapli/api_docs/driver/generic_driver/) 
-- [`NetworkDriver` Arguments](https://carlmontanari.github.io/scrapli/api_docs/driver/network_driver/) 
+- [Base `Driver` Arguments](https://carlmontanari.github.io/scrapli/reference/driver/base/base_driver/) 
 
 Most of these attributes actually get passed from the `Driver` (or sub-class such as `NXOSDriver`) into the
  `Transport` and `Channel` classes, so if you need to modify any of these values after instantiation you should do so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,34 @@
 [build-system]
-requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+requires = [
+  "setuptools",
+  "wheel",
+]
 
 [project]
 name = "scrapli"
-dynamic = [
-    "version",
-    "dependencies",
-    "optional-dependencies",
-]
 description = "Fast, flexible, sync/async, Python 3.7+ screen scraping client specifically for network devices"
 readme = "README.md"
+keywords = [
+  "arista",
+  "automation",
+  "cisco",
+  "eos",
+  "iosxe",
+  "iosxr",
+  "juniper",
+  "junos",
+  "netconf",
+  "network",
+  "nxos",
+  "ssh",
+  "telnet",
+]
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
 authors = [
     { name = "Carl Montanari", email = "carl.r.montanari@gmail.com" },
 ]
+requires-python = ">=3.7"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
@@ -29,26 +42,15 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-keywords = [
-    "ssh",
-    "telnet",
-    "netconf",
-    "automation",
-    "network",
-    "cisco",
-    "iosxr",
-    "iosxe",
-    "nxos",
-    "arista",
-    "eos",
-    "juniper",
-    "junos",
+dynamic = [
+  "dependencies",
+  "optional-dependencies",
+  "version",
 ]
-
 [project.urls]
-Homepage = "https://github.com/carlmontanari/scrapli"
 Changelog = "https://carlmontanari.github.io/scrapli/changelog"
 Docs = "https://carlmontanari.github.io/scrapli/"
+Homepage = "https://github.com/carlmontanari/scrapli"
 
 [tool.setuptools.dynamic]
 version = { attr = "scrapli.__version__" }
@@ -77,6 +79,22 @@ scrapli = [
     "py.typed"
 ]
 
+[tool.black]
+line-length = 100
+target-version = [
+    "py311",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+multi_line_output = 3
+include_trailing_comma = true
+known_first_party = "scrapli"
+known_third_party = "asyncssh,pytest"
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [tool.coverage.run]
 source = [
     "scrapli/"
@@ -89,13 +107,17 @@ omit = [
 sort = "cover"
 omit = ["scrapli/transport/plugins/system/ptyprocess.py"]
 
-[tool.black]
-line-length = 100
-target-version = [
-    "py311",
-]
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
+[tool.mypy]
+python_version = "3.11"
+pretty = true
+ignore_missing_imports = true
+warn_redundant_casts = true
+warn_unused_configs = true
+strict_optional = true
+
+[[tool.mypy.overrides]]
+module = "scrapli.transport.plugins.system.ptyprocess"
+ignore_errors = true
 
 [tool.pylama]
 linters = "mccabe,pycodestyle,pylint"
@@ -120,23 +142,3 @@ ignore = "D101,D202,D203,D212,D400,D406,D407,D408,D409,D415"
 # D408: Section underline should be in the line following the sections name
 # D409: Section underline should match the length of its name
 # D415: first line should end with a period, question mark, or exclamation point
-
-[tool.isort]
-profile = "black"
-line_length = 100
-multi_line_output = 3
-include_trailing_comma = true
-known_first_party = "scrapli"
-known_third_party = "asyncssh,pytest"
-
-[tool.mypy]
-python_version = "3.11"
-pretty = true
-ignore_missing_imports = true
-warn_redundant_casts = true
-warn_unused_configs = true
-strict_optional = true
-
-[[tool.mypy.overrides]]
-module = "scrapli.transport.plugins.system.ptyprocess"
-ignore_errors = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,13 @@
 black==23.1.0
 darglint>=1.8.1,<2.0.0
 isort>=5.10.1,<6.0.0
-mypy==1.0.1
+mypy==1.1.1
 nox==2022.11.21
 pycodestyle>=2.8.0,<3.0.0
 pydocstyle>=6.1.1,<7.0.0
 pyfakefs>=5.0.0,<6.0.0
 pylama>=8.4.0,<9.0.0
-pylint==2.16.2
+pylint==2.17.1
 pytest-asyncio>=0.17.0,<1.0.0
 pytest-cov>=3.0.0,<5.0.0
 pytest>=7.0.0,<8.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,13 @@
-black==23.1.0
+black==23.3.0
 darglint>=1.8.1,<2.0.0
 isort>=5.10.1,<6.0.0
-mypy==1.1.1
+mypy==1.2.0
 nox==2022.11.21
 pycodestyle>=2.8.0,<3.0.0
 pydocstyle>=6.1.1,<7.0.0
 pyfakefs>=5.0.0,<6.0.0
 pylama>=8.4.0,<9.0.0
-pylint==2.17.1
+pylint==2.17.2
 pytest-asyncio>=0.17.0,<1.0.0
 pytest-cov>=3.0.0,<5.0.0
 pytest>=7.0.0,<8.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,13 @@
-black==22.12.0
+black==23.1.0
 darglint>=1.8.1,<2.0.0
 isort>=5.10.1,<6.0.0
-mypy==0.991
+mypy==1.0.1
 nox==2022.11.21
 pycodestyle>=2.8.0,<3.0.0
 pydocstyle>=6.1.1,<7.0.0
 pyfakefs>=5.0.0,<6.0.0
 pylama>=8.4.0,<9.0.0
-pylint==2.15.10
+pylint==2.16.2
 pytest-asyncio>=0.17.0,<1.0.0
 pytest-cov>=3.0.0,<5.0.0
 pytest>=7.0.0,<8.0.0

--- a/scrapli/channel/base_channel.py
+++ b/scrapli/channel/base_channel.py
@@ -396,6 +396,15 @@ class BaseChannel:
             msg = "Timed out connecting to host"
         elif b"no route to host" in output.lower():
             msg = "No route to host"
+        elif b"no matching host key" in output.lower():
+            msg = "No matching host key type found for host"
+            key_exchange_pattern = re.compile(
+                pattern=rb"their offer: ([a-z0-9\-,]*)", flags=re.M | re.I
+            )
+            offered_key_exchanges_match = re.search(pattern=key_exchange_pattern, string=output)
+            if offered_key_exchanges_match:
+                offered_key_exchanges = offered_key_exchanges_match.group(1).decode()
+                msg += f", their offer: {offered_key_exchanges}"
         elif b"no matching key exchange" in output.lower():
             msg = "No matching key exchange found for host"
             key_exchange_pattern = re.compile(

--- a/scrapli/transport/plugins/asyncssh/transport.py
+++ b/scrapli/transport/plugins/asyncssh/transport.py
@@ -224,7 +224,6 @@ class AsyncsshTransport(AsyncTransport):
         self._pre_open_closing_log(closing=True)
 
         if self.session:
-
             with suppress(BrokenPipeError):
                 # this may raise a BrokenPipeError because seems it is possible for the connection
                 # transport is_closing() to be true already in some cases... since we are closing

--- a/tests/prepare_devices.py
+++ b/tests/prepare_devices.py
@@ -40,7 +40,6 @@ def prepare_device(test_devices):
         }
 
         with Scrapli(**conn_dict) as conn:
-
             if device == "cisco_iosxe":
                 # getting existing crypto "stuff" from the device to stuff it into config template
                 # to avoid netconf complaints -- replacing crypto was strings caused things to not

--- a/tests/unit/channel/test_base_channel.py
+++ b/tests/unit/channel/test_base_channel.py
@@ -190,6 +190,14 @@ def test_channel_send_return(monkeypatch, base_channel):
             "No route to host",
         ),
         (
+            b"no matching host key type found",
+            "No matching host key type found for host",
+        ),
+        (
+            b"Unable to negotiate with 172.20.20.12 port 22: no matching host key type found. Their offer: ssh-rsa",
+            "No matching host key type found for host, their offer: ssh-rsa",
+        ),
+        (
             b"no matching key exchange found.",
             "No matching key exchange found",
         ),
@@ -229,6 +237,8 @@ def test_channel_send_return(monkeypatch, base_channel):
         "operation time out",
         "connection time out",
         "no route to host",
+        "no matching host key type",
+        "no matching host key type found key type",
         "no matching key exchange",
         "no matching key exchange found key exchange",
         "no matching cipher",


### PR DESCRIPTION
In continuation https://github.com/carlmontanari/scrapli/discussions/281  

Adding the _post_init method to the base class. This method could be called after the init method of the underlying sync/async drivers.

Needed for e.g. redefinition  
```
conn.channel._auth_telnet_login_pattern
```