### PR TITLE
_post_init()

### DIFF
--- a/scrapli/driver/base/async_driver.py
+++ b/scrapli/driver/base/async_driver.py
@@ -25,6 +25,9 @@ class AsyncDriver(BaseDriver):
             base_channel_args=self._base_channel_args,
         )
 
+        if self.on_init:
+            self.on_init(self)
+
     async def __aenter__(self: _T) -> _T:
         """
         Enter method for context manager

--- a/scrapli/driver/base/base_driver.py
+++ b/scrapli/driver/base/base_driver.py
@@ -189,9 +189,6 @@ class BaseDriver:
             plugin_transport_args=self._plugin_transport_args,
         )
 
-        if self.on_init:
-            self.on_init(self)
-
     def __str__(self) -> str:
         """
         Magic str method for Scrape

--- a/scrapli/driver/base/sync_driver.py
+++ b/scrapli/driver/base/sync_driver.py
@@ -24,6 +24,17 @@ class Driver(BaseDriver):
             transport=self.transport,
             base_channel_args=self._base_channel_args,
         )
+        
+    def _post_init(self) -> None:
+        """
+        Adding the _post_init method to the base class. 
+        This method could be called after the init method 
+        of the underlying sync/async drivers.
+
+        Needed for e.g. redefinition
+        conn.channel._auth_telnet_login_pattern
+        """
+        pass
 
     def __enter__(self: _T) -> _T:
         """

--- a/scrapli/driver/base/sync_driver.py
+++ b/scrapli/driver/base/sync_driver.py
@@ -24,17 +24,11 @@ class Driver(BaseDriver):
             transport=self.transport,
             base_channel_args=self._base_channel_args,
         )
-        
-    def _post_init(self) -> None:
-        """
-        Adding the _post_init method to the base class. 
-        This method could be called after the init method 
-        of the underlying sync/async drivers.
 
-        Needed for e.g. redefinition
-        conn.channel._auth_telnet_login_pattern
-        """
-        pass
+        # ensure the "on_init" func is called in the actual driver (sync/async rather than the base
+        # class) since we want to wait until after the channel is setup!
+        if self.on_init:
+            self.on_init(self)
 
     def __enter__(self: _T) -> _T:
         """

--- a/tests/unit/driver/base/test_base_async_driver.py
+++ b/tests/unit/driver/base/test_base_async_driver.py
@@ -13,6 +13,33 @@ def test_sync_transport_exception():
         AsyncDriver(host="localhost", transport="system")
 
 
+@pytest.mark.parametrize(
+    "test_data",
+    (True, False),
+    ids=(
+        "on_init",
+        "no_on_init",
+    ),
+)
+def test_on_init(test_data):
+    """Assert on init method is executed at end of driver initialization (if provided)"""
+    test_on_init = test_data
+    on_init_called = False
+
+    def _on_init(cls):
+        nonlocal on_init_called
+        on_init_called = True
+
+    AsyncDriver(
+        host="localhost", transport="asynctelnet", on_init=_on_init if test_on_init else None
+    )
+
+    if test_on_init:
+        assert on_init_called is True
+    else:
+        assert on_init_called is False
+
+
 async def test_context_manager(monkeypatch):
     """Asserts context manager properly opens/closes"""
     channel_telnet_auth_called = False

--- a/tests/unit/driver/base/test_base_base_driver.py
+++ b/tests/unit/driver/base/test_base_base_driver.py
@@ -300,31 +300,6 @@ def test_isalive(monkeypatch, base_driver, test_data):
 
 @pytest.mark.parametrize(
     "test_data",
-    (True, False),
-    ids=(
-        "on_init",
-        "no_on_init",
-    ),
-)
-def test_on_init(test_data):
-    """Assert on init method is executed at end of driver initialization (if provided)"""
-    test_on_init = test_data
-    on_init_called = False
-
-    def _on_init(cls):
-        nonlocal on_init_called
-        on_init_called = True
-
-    BaseDriver(host="localhost", on_init=_on_init if test_on_init else None)
-
-    if test_on_init:
-        assert on_init_called is True
-    else:
-        assert on_init_called is False
-
-
-@pytest.mark.parametrize(
-    "test_data",
     (
         (False, "opening connection to 'localhost' on port '22'"),
         (True, "closing connection to 'localhost' on port '22'"),

--- a/tests/unit/driver/base/test_base_sync_driver.py
+++ b/tests/unit/driver/base/test_base_sync_driver.py
@@ -13,6 +13,31 @@ def test_async_transport_exception():
         Driver(host="localhost", transport="asynctelnet")
 
 
+@pytest.mark.parametrize(
+    "test_data",
+    (True, False),
+    ids=(
+        "on_init",
+        "no_on_init",
+    ),
+)
+def test_on_init(test_data):
+    """Assert on init method is executed at end of driver initialization (if provided)"""
+    test_on_init = test_data
+    on_init_called = False
+
+    def _on_init(cls):
+        nonlocal on_init_called
+        on_init_called = True
+
+    Driver(host="localhost", on_init=_on_init if test_on_init else None)
+
+    if test_on_init:
+        assert on_init_called is True
+    else:
+        assert on_init_called is False
+
+
 def test_context_manager(monkeypatch):
     """Asserts context manager properly opens/closes"""
     channel_ssh_auth_called = False


### PR DESCRIPTION
In continuation https://github.com/carlmontanari/scrapli/discussions/281

Adding the _post_init method to the base class. This method could be called after the init method of the underlying sync/async drivers.

Needed for e.g. redefinition
```
conn.channel._auth_telnet_login_pattern
```
PS
Unfortunately, my knowledge is not enough to formalize the code correctly.
Only denote
