### PR TITLE
restore timeout_ops whatever happened

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -47,7 +47,7 @@ jobs:
           TERM: xterm
         run: python -m nox -s unit_tests-3.11
       - name: Upload coverage
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3.1.3
 
   build_posix:
     runs-on: ${{ matrix.os }}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@ Changelog
 ## 2023.07.30 (in development)
 
 - Expand channel auth patterns to include "no matching host key"
+- Always restore `timeout_ops` even in the event of a timeout -- thank you to @erwinkinn, and please see #289 and #285 
+  for more info
 
 
 ## 2023.01.30

--- a/scrapli/decorators.py
+++ b/scrapli/decorators.py
@@ -279,8 +279,10 @@ def timeout_modifier(wrapped_func: Callable[..., Any]) -> Callable[..., Any]:
                 )
                 base_timeout_ops = driver_instance.timeout_ops
                 driver_instance.timeout_ops = kwargs["timeout_ops"]
-                result = await wrapped_func(*args, **kwargs)
-                driver_instance.timeout_ops = base_timeout_ops
+                try:
+                    result = await wrapped_func(*args, **kwargs)
+                finally:
+                    driver_instance.timeout_ops = base_timeout_ops
             return result
 
     else:


### PR DESCRIPTION
# Description

The problem is when I set the special timeout for the operation and then handle ScrapliTimeout  (Why am I doing it? This why: https://github.com/carlmontanari/scrapli/issues/285 ;)) and proceed my script execution, I see that the timeout  remains actual for the second and all the rest of further commands. The reason is obvious.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually. 

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
