### PR TITLE
feat: skip killing connection on timeouts (optionally)

### DIFF
--- a/scrapli/decorators.py
+++ b/scrapli/decorators.py
@@ -9,6 +9,7 @@ from logging import Logger, LoggerAdapter
 from typing import TYPE_CHECKING, Any, Callable, Tuple
 
 from scrapli.exceptions import ScrapliTimeout
+from scrapli.settings import Settings
 
 if TYPE_CHECKING:
     from scrapli.driver import AsyncGenericDriver, GenericDriver  # pragma:  no cover
@@ -129,8 +130,14 @@ def _handle_timeout(transport: "BaseTransport", logger: LoggerAdapterT, message:
         ScrapliTimeout: always, if we hit this method we have already timed out!
 
     """
-    logger.critical("operation timed out, closing connection")
-    transport.close()
+    if Settings.NO_TERMINATE_ON_TIMEOUT:
+        logger.critical(
+            "operation timed out, NO_TERMINATE_ON_TIMEOUT is true, not closing connection"
+        )
+    else:
+        logger.critical("operation timed out, closing connection")
+        transport.close()
+
     raise ScrapliTimeout(message)
 
 

--- a/scrapli/settings.py
+++ b/scrapli/settings.py
@@ -2,4 +2,7 @@
 
 
 class Settings:
+    # supress user warnings for things like strict key
     SUPPRESS_USER_WARNINGS = False
+    # when true, do *not* terminate connections when timeouts occur
+    NO_TERMINATE_ON_TIMEOUT = False


### PR DESCRIPTION
hey @rlad78 and @erwinkinn -- how does this look to deal with what we discussed in #285?

this plus the other pr from @erwinkin hopefully solves most things?

I think if somebody were willing to add it I would also be open to the idea of a post close function.. I was thinking about our other conversation and the `on_init` func already exists... so it wouldn't be a huge stretch to add a `post_close` or something. How/where that would be is obviously a bit trickier. I suppose if we just added that in the base driver `close` method and you had that plus this pr, things would work ok. offhand I dont think `close` can fail (ex: in asyncssh we suppress the only thing that may get raised I think).

anyway, open to more thoughts/additions of course! but hopefully this sorts things in the short term. just a quick example below and its seems to work nicely. lemme know what ya'll think!

example:

```python
from scrapli import Scrapli
from scrapli.exceptions import ScrapliTimeout
from scrapli.settings import Settings

Settings.NO_TERMINATE_ON_TIMEOUT = True


def main():
    dev = {
        # your stuff
    }

    conn = Scrapli(**dev)

    conn.open()

    try:
        conn.send_command(command="show run", timeout_ops=0.1)
    except ScrapliTimeout:
        print("timed out")

    print(conn.get_prompt())


if __name__ == "__main__":
    main()
```