### PR TITLE
Better type hints for decorators

### DIFF
--- a/scrapli/decorators.py
+++ b/scrapli/decorators.py
@@ -21,6 +21,14 @@ else:
 
 _IS_WINDOWS = sys.platform.startswith("win")
 
+if sys.version_info < (3, 10):
+    OriginalFunc = Callable[..., Any]
+else:
+    # Thanks to https://stackoverflow.com/questions/47060133/python-3-type-hinting-for-decorator
+    from typing import ParamSpec, TypeVar
+    Param = ParamSpec("Param")
+    RetType = TypeVar("RetType")
+    OriginalFunc = Callable[Param, RetType]
 
 FUNC_TIMEOUT_MESSAGE_MAP = {
     "channel_authenticate_ssh": "timed out during in channel ssh authentication",
@@ -165,7 +173,7 @@ def _get_transport_logger_timeout(
     )
 
 
-def timeout_wrapper(wrapped_func: Callable[..., Any]) -> Callable[..., Any]:
+def timeout_wrapper(wrapped_func: OriginalFunc) -> OriginalFunc:
     """
     Timeout wrapper for transports
 
@@ -244,7 +252,7 @@ def timeout_wrapper(wrapped_func: Callable[..., Any]) -> Callable[..., Any]:
     return decorate
 
 
-def timeout_modifier(wrapped_func: Callable[..., Any]) -> Callable[..., Any]:
+def timeout_modifier(wrapped_func: OriginalFunc) -> OriginalFunc:
     """
     Decorate an "operation" to modify the timeout_ops value for duration of that operation
 


### PR DESCRIPTION
# Description

PEP 612 was added to python 3.10 and that lets us give users better type hints for functions like send_and_read and send_interactive.


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with vscode and python 3.10


# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
