### PR TITLE
Remove all ANSI codes from buf

### DIFF
--- a/scrapli/channel/base_channel.py
+++ b/scrapli/channel/base_channel.py
@@ -10,7 +10,15 @@ from scrapli.exceptions import ScrapliAuthenticationFailed, ScrapliTypeError, Sc
 from scrapli.logging import get_instance_logger
 from scrapli.transport.base import AsyncTransport, Transport
 
-ANSI_ESCAPE_PATTERN = re.compile(rb"\x1b(\[.*?[@-~]|\].*?(\x07|\x1b\\)|E)")
+ANSI_ESCAPE_PATTERN = re.compile(
+    rb"[\x1B\x9B]"
+    rb"[\[\]()#;?]*"
+    rb"("
+    rb"(([a-zA-Z0-9]*(;[a-zA-Z\d]*)*)?\x07)"
+    rb"|"
+    rb"((\d{1,4}(;\d{0,4})*)?[\dA-PRZcf-ntqry=><~])"
+    rb")"
+)
 
 
 @dataclass()

--- a/tests/unit/channel/test_base_channel.py
+++ b/tests/unit/channel/test_base_channel.py
@@ -292,6 +292,14 @@ def test_process_output(base_channel):
             b"VeryLong\x1bECommand",
             b"VeryLongCommand",
         ),
+        (
+            b"command-prompt# \x1b7",
+            b"command-prompt# ",
+        ),
+        (
+            b"\x1b[7mCTRL+C\x1b[0m \x1b[7mESC\x1b[0m \x1b[7mq\x1b[0m Quit \x1b[7mSPACE\x1b[0m \x1b[7mn\x1b[0m Next Page \x1b[7mENTER\x1b[0m Next Entry \x1b[7ma\x1b[0m All\x1b[1A\x1b[59C\x1b[27m",
+            b"CTRL+C ESC q Quit SPACE n Next Page ENTER Next Entry a All",
+        ),
     ),
 )
 def test_strip_ansi(base_channel, buf: bytes, expected: bytes):


### PR DESCRIPTION
# Description

As discussed in the discussion #301, these regular expression modifications allow all possible combinations of ANSI codes to be removed from the buffer probably.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The following unit test was augmented with two parameters:
```python
@pytest.mark.parametrize(
    "buf, expected",
    (
        (
            b"[admin@CoolDevice.Sea1: \x1b[1m/\x1b[0;0m]$",
            b"[admin@CoolDevice.Sea1: /]$",
        ),
        (
            b"VeryLong\x1bECommand",
            b"VeryLongCommand",
        ),
        (
            b"command-prompt# \x1b7",
            b"command-prompt# ",
        ),
        (
            b"\x1b[7mCTRL+C\x1b[0m \x1b[7mESC\x1b[0m \x1b[7mq\x1b[0m Quit \x1b[7mSPACE\x1b[0m \x1b[7mn\x1b[0m Next Page \x1b[7mENTER\x1b[0m Next Entry \x1b[7ma\x1b[0m All\x1b[1A\x1b[59C\x1b[27m",
            b"CTRL+C ESC q Quit SPACE n Next Page ENTER Next Entry a All",
        ),
    ),
)
def test_strip_ansi(base_channel, buf: bytes, expected: bytes):
    actual_strip_ansi_output = base_channel._strip_ansi(buf=buf)
    assert actual_strip_ansi_output == expected
```

Regarding the successful execution of all unit tests, some tests that depend on the presence of an SSH server on the host failed as expected. I mean tests using `socket_transport`. I also wrote about it in the discussion #301.

# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
