### PR TITLE
: pass parameters if given initial_input

### DIFF
--- a/scrapli/driver/generic/async_driver.py
+++ b/scrapli/driver/generic/async_driver.py
@@ -530,7 +530,13 @@ class AsyncGenericDriver(AsyncDriver, BaseGenericDriver):
         """
         if initial_input is not None:
             self.channel.write(channel_input=f"{initial_input}{self.comms_return_char}")
-            return await self.read_callback(callbacks=callbacks, initial_input=None)
+            return await self.read_callback(
+                callbacks=callbacks,
+                initial_input=None,
+                read_output=read_output,
+                read_delay=read_delay,
+                read_timeout=read_timeout,
+            )
 
         original_transport_timeout = self.timeout_transport
 

--- a/scrapli/driver/generic/sync_driver.py
+++ b/scrapli/driver/generic/sync_driver.py
@@ -531,7 +531,13 @@ class GenericDriver(Driver, BaseGenericDriver):
         """
         if initial_input is not None:
             self.channel.write(channel_input=f"{initial_input}{self.comms_return_char}")
-            return self.read_callback(callbacks=callbacks, initial_input=None)
+            return self.read_callback(
+                callbacks=callbacks,
+                initial_input=None,
+                read_output=read_output,
+                read_delay=read_delay,
+                read_timeout=read_timeout,
+            )
 
         original_transport_timeout = self.timeout_transport
 


### PR DESCRIPTION
# Description

If read_callback is given an initial_input, then read_callback does a write and recursively calls itself. Only the callback parameter is passed to that recursive call, preventing any other parameter from having an effect.

fix issue #304 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All unit tests pass

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] New and existing unit tests pass locally with my changes
