### PR TITLE
Update ANSI_ESCAPE_PATTERN for discussion #313

### DIFF
--- a/scrapli/channel/base_channel.py
+++ b/scrapli/channel/base_channel.py
@@ -17,7 +17,7 @@ ANSI_ESCAPE_PATTERN = re.compile(
     rb"|"
     rb"([\x07])"  # BEL (Terminal bell)
     rb"|"
-    rb"(\[[{}();#=?0-9]*[A-Zhlnmsu~])"  # control codes starts with `[` e.x. ESC [2;37;41m
+    rb"(\[[{}();#=?0-9]*[A-Zhglnmsu~])"  # control codes starts with `[` e.x. ESC [2;37;41m
     rb")",
     flags=re.VERBOSE,
 )

--- a/scrapli/channel/base_channel.py
+++ b/scrapli/channel/base_channel.py
@@ -11,13 +11,15 @@ from scrapli.logging import get_instance_logger
 from scrapli.transport.base import AsyncTransport, Transport
 
 ANSI_ESCAPE_PATTERN = re.compile(
-    rb"[\x1B\x9B]"
-    rb"[\[\]()#;?]*"
+    pattern=rb"[\x1B\x9B\x9D](\s)?"  # Prefix ESC (^) or CSI (^[) or OSC (^])
     rb"("
-    rb"(([a-zA-Z0-9]*(;[a-zA-Z\d]*)*)?\x07)"
+    rb"([78ME])"  # control cursor position
     rb"|"
-    rb"((\d{1,4}(;\d{0,4})*)?[\dA-PRZcf-ntqry=><~])"
-    rb")"
+    rb"([\x07])"  # BEL (Terminal bell)
+    rb"|"
+    rb"(\[[{}();#=?0-9]*[A-Zhlnmsu~])"  # control codes starts with `[` e.x. ESC [2;37;41m
+    rb")",
+    flags=re.VERBOSE,
 )
 
 

--- a/tests/unit/channel/test_base_channel.py
+++ b/tests/unit/channel/test_base_channel.py
@@ -301,6 +301,50 @@ def test_process_output(base_channel):
             b"CTRL+C ESC q Quit SPACE n Next Page ENTER Next Entry a All",
         ),
         (
+            b"foo\x1B[4mcake\x1B[0m'",
+            b"foocake'",
+        ),
+        (
+            b"\x1B[4mcake\x1B[0m",
+            b"cake",
+        ),
+        (
+            b"foo\x1B[4mcake\x1B[0m",
+            b"foocake",
+        ),
+        (
+            b"\x1B[0m\x1B[4m\x1B[42m\x1B[31mfoo\x1B[39m\x1B[49m\x1B[24mfoo\x1B[0m",
+            b"foofoo",
+        ),
+        (
+            b"foo\x1B[mfoo",
+            b"foofoo",
+        ),
+        (
+            b"\x1B[00;38;5;244m\x1B[m\x1B[00;38;5;33mfoo\x1B[0m",
+            b"foo",
+        ),
+        (
+            b"\x1B[0;33;49;3;9;4mbar\x1B[0m",
+            b"bar",
+        ),
+        (
+            b"foo\x1B[0;33;49;3;9;4mbar",
+            b"foobar",
+        ),
+        (
+            b"foo\x1B[0gbar",
+            b"foobar",
+        ),
+        (
+            b"foo\x1B[Kbar",
+            b"foobar",
+        ),
+        (
+            b"foo\x1B[2Jbar",
+            b"foobar",
+        ),
+        (
             b"\x1b7c\x1b8\x1b[1C\x1b7o\x1b8\x1b[1C\x1b7n\x1b8\x1b[1C\x1b7f\x1b8\x1b[1C\x1b7i\x1b8\x1b[1C\x1b7g\x1b8\x1b[1C\x1b7u\x1b8\x1b[1C\x1b7r\x1b8\x1b[1C\x1b7e\x1b8\x1b[1C",
             b"configure",
         ),

--- a/tests/unit/channel/test_base_channel.py
+++ b/tests/unit/channel/test_base_channel.py
@@ -300,6 +300,10 @@ def test_process_output(base_channel):
             b"\x1b[7mCTRL+C\x1b[0m \x1b[7mESC\x1b[0m \x1b[7mq\x1b[0m Quit \x1b[7mSPACE\x1b[0m \x1b[7mn\x1b[0m Next Page \x1b[7mENTER\x1b[0m Next Entry \x1b[7ma\x1b[0m All\x1b[1A\x1b[59C\x1b[27m",
             b"CTRL+C ESC q Quit SPACE n Next Page ENTER Next Entry a All",
         ),
+        (
+            b"\x1b7c\x1b8\x1b[1C\x1b7o\x1b8\x1b[1C\x1b7n\x1b8\x1b[1C\x1b7f\x1b8\x1b[1C\x1b7i\x1b8\x1b[1C\x1b7g\x1b8\x1b[1C\x1b7u\x1b8\x1b[1C\x1b7r\x1b8\x1b[1C\x1b7e\x1b8\x1b[1C",
+            b"configure",
+        ),
     ),
 )
 def test_strip_ansi(base_channel, buf: bytes, expected: bytes):


### PR DESCRIPTION
# Description

Modify the ANSI_ESCAPE_PATTERN regular expression so that it honors the control characters described in #313.

Also added comments inside the regular expression to simplify future edits.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
 list any relevant details for your test configuration


# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
