### PR TITLE
Add maintenance mode in cisco_nxos prompt patterns

### DIFF
--- a/scrapli/driver/core/cisco_nxos/base_driver.py
+++ b/scrapli/driver/core/cisco_nxos/base_driver.py
@@ -8,7 +8,7 @@ from scrapli.exceptions import ScrapliValueError
 PRIVS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^[\w.\-]{1,63}>\s?$",
+            pattern=r"^[\w.\-]{1,63}(\(maint\-mode\))?>\s?$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -19,7 +19,7 @@ PRIVS = {
     ),
     "privilege_exec": (
         PrivilegeLevel(
-            pattern=r"^[\w.\-]{1,63}#\s?$",
+            pattern=r"^[\w.\-]{1,63}(\(maint\-mode\))?#\s?$",
             name="privilege_exec",
             previous_priv="exec",
             deescalate="disable",
@@ -31,7 +31,7 @@ PRIVS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^[\w.\-]{1,63}\(config[\w.\-@/:\+]{0,32}\)#\s?$",
+            pattern=r"^[\w.\-]{1,63}(\(maint\-mode\))?\(config[\w.\-@/:\+]{0,32}\)#\s?$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="end",
@@ -47,7 +47,8 @@ PRIVS = {
             # for now doesnt seem to be a reason to differentiate between them, so just have one
             # giant pattern
             pattern=(
-                r"(^[\w.\-]{1,63}\-tcl#\s?$)|" r"(^[\w.\-]{1,63}\(config\-tcl\)#\s?$)|" r"(^>\s?$)"
+                r"(^[\w.\-]{1,63}\-tcl#\s?$)|" r"(^[\w.\-]{1,63}\(config\-tcl\)#\s?$)|" r"(^>\s?$)|"
+                r"(^[\w.\-]{1,63}\(maint\-\mode\-tcl\)#\s?$)|" r"(^[\w.\-]{1,63}\(maint\-\mode\)\(config\-tcl\)#\s?$)"
             ),
             name="tclsh",
             previous_priv="privilege_exec",


### PR DESCRIPTION
Handling maintenance mode (maint-mode) in prompts on Cisco NX-OS.

# Description

When maintenance mode is activated on Cisco NX-OS (with config command "system mode maintenance"), device's prompt is modified as below:
- Privileged: hostname(maint-mode)# 
- Config: hostname(maint-mode)(config)#
- Tclsh privlieged: hostname(maint-mode-tcl)#
- Tclsh config: hostname(maint-mode)(config-tcl)#

This PR proposes the modification of related cisco_nxos base_driver.py patterns.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with real device by modifying the following properties of scrapli object:
- connection.comms_prompt_pattern
- connection.privilege_levels.values.pattern of 'privilege_exec' and 'configuration'

This hasn't unfortunately been tested on unprivileged mode.