### PR TITLE
Transport name validation only for core transport (to fix non-core transport loading)

### DIFF
--- a/scrapli/driver/base/async_driver.py
+++ b/scrapli/driver/base/async_driver.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Type, TypeVar
 from scrapli.channel import AsyncChannel
 from scrapli.driver.base.base_driver import BaseDriver
 from scrapli.exceptions import ScrapliValueError
-from scrapli.transport import ASYNCIO_TRANSPORTS
+from scrapli.transport import CORE_TRANSPORTS, ASYNCIO_TRANSPORTS
 
 _T = TypeVar("_T", bound="AsyncDriver")
 
@@ -15,7 +15,7 @@ class AsyncDriver(BaseDriver):
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
 
-        if self.transport_name not in ASYNCIO_TRANSPORTS:
+        if self.transport_name in CORE_TRANSPORTS and self.transport_name not in ASYNCIO_TRANSPORTS:
             raise ScrapliValueError(
                 "provided transport is *not* an asyncio transport, must use an async transport with"
                 " the AsyncDriver(s)"
@@ -89,11 +89,7 @@ class AsyncDriver(BaseDriver):
         self.channel.open()
 
         if (
-            self.transport_name
-            in (
-                "telnet",
-                "asynctelnet",
-            )
+            "telnet" in self.transport_name
             and not self.auth_bypass
         ):
             await self.channel.channel_authenticate_telnet(

--- a/scrapli/driver/base/sync_driver.py
+++ b/scrapli/driver/base/sync_driver.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Type, TypeVar
 from scrapli.channel import Channel
 from scrapli.driver.base.base_driver import BaseDriver
 from scrapli.exceptions import ScrapliValueError
-from scrapli.transport import ASYNCIO_TRANSPORTS
+from scrapli.transport import CORE_TRANSPORTS, ASYNCIO_TRANSPORTS
 
 _T = TypeVar("_T", bound="Driver")
 
@@ -15,7 +15,7 @@ class Driver(BaseDriver):
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
 
-        if self.transport_name in ASYNCIO_TRANSPORTS:
+        if self.transport_name in CORE_TRANSPORTS and self.transport_name in ASYNCIO_TRANSPORTS:
             raise ScrapliValueError(
                 "provided transport is *not* an sync transport, must use an sync transport with"
                 " the (sync)Driver(s)"
@@ -96,11 +96,7 @@ class Driver(BaseDriver):
                 auth_private_key_passphrase=self.auth_private_key_passphrase,
             )
         if (
-            self.transport_name
-            in (
-                "telnet",
-                "asynctelnet",
-            )
+            "telnet" in self.transport_name
             and not self.auth_bypass
         ):
             self.channel.channel_authenticate_telnet(

--- a/scrapli/factory.py
+++ b/scrapli/factory.py
@@ -27,7 +27,7 @@ from scrapli.exceptions import (
 )
 from scrapli.helper import format_user_warning
 from scrapli.logging import logger
-from scrapli.transport import ASYNCIO_TRANSPORTS
+from scrapli.transport import CORE_TRANSPORTS, ASYNCIO_TRANSPORTS
 
 
 def _build_provided_kwargs_dict(  # pylint: disable=R0914
@@ -465,8 +465,8 @@ class Scrapli(NetworkDriver):
         """
         logger.debug("Scrapli factory initialized")
 
-        if transport in ASYNCIO_TRANSPORTS:
-            raise ScrapliValueError("Use 'AsyncScrapli' if using an async transport!")
+        if transport in CORE_TRANSPORTS and transport in ASYNCIO_TRANSPORTS:
+                raise ScrapliValueError("Use 'AsyncScrapli' if using an async transport!")
 
         if not isinstance(platform, str):
             raise ScrapliTypeError(f"Argument 'platform' must be 'str' got '{type(platform)}'")
@@ -764,8 +764,8 @@ class AsyncScrapli(AsyncNetworkDriver):
         """
         logger.debug("AsyncScrapli factory initialized")
 
-        if transport not in ASYNCIO_TRANSPORTS:
-            raise ScrapliValueError("Use 'Scrapli' if using a synchronous transport!")
+        if transport in CORE_TRANSPORTS and transport not in ASYNCIO_TRANSPORTS:
+                raise ScrapliValueError("Use 'Scrapli' if using a synchronous transport!")
 
         if not isinstance(platform, str):
             raise ScrapliTypeError(f"Argument 'platform' must be 'str' got '{type(platform)}'")

--- a/scrapli/factory.py
+++ b/scrapli/factory.py
@@ -466,7 +466,7 @@ class Scrapli(NetworkDriver):
         logger.debug("Scrapli factory initialized")
 
         if transport in CORE_TRANSPORTS and transport in ASYNCIO_TRANSPORTS:
-                raise ScrapliValueError("Use 'AsyncScrapli' if using an async transport!")
+            raise ScrapliValueError("Use 'AsyncScrapli' if using an async transport!")
 
         if not isinstance(platform, str):
             raise ScrapliTypeError(f"Argument 'platform' must be 'str' got '{type(platform)}'")
@@ -765,7 +765,7 @@ class AsyncScrapli(AsyncNetworkDriver):
         logger.debug("AsyncScrapli factory initialized")
 
         if transport in CORE_TRANSPORTS and transport not in ASYNCIO_TRANSPORTS:
-                raise ScrapliValueError("Use 'Scrapli' if using a synchronous transport!")
+            raise ScrapliValueError("Use 'Scrapli' if using a synchronous transport!")
 
         if not isinstance(platform, str):
             raise ScrapliTypeError(f"Argument 'platform' must be 'str' got '{type(platform)}'")


### PR DESCRIPTION
# Description

As discussed in #327, custom/third-party transports are supported  (see [`_load_non_core_transport_plugin`](https://github.com/carlmontanari/scrapli/blob/5c4e7bc97e61bb21bf2706a5bf76a8b60b197091/scrapli/driver/base/base_driver.py#L560)) but because the transport name is checked against `scrapli.transport.ASYNCIO_TRANSPORTS` (in both [AsyncScrapli](https://github.com/carlmontanari/scrapli/blob/5c4e7bc97e61bb21bf2706a5bf76a8b60b197091/scrapli/factory.py#L767) and [async_driver](https://github.com/carlmontanari/scrapli/blob/5c4e7bc97e61bb21bf2706a5bf76a8b60b197091/scrapli/driver/base/async_driver.py#L18)) async *non-core* transports cannot actually be loaded.

This PR modifies this behavior so that the `ASYNCIO_TRANSPORTS` checks occur only for core transports (`scrapli.transport.CORE_TRANSPORTS`).


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added  `test_transport_factory_non_core` in `test_base_base_driver` to check that `_transport_factory` correctly loads the custom transport class (and arguments) from the appropriate plugin module.

# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
