### PR TITLE
Issue #336, ssh_config_file and ssh_known_hosts_file True behaviour with system transport

### DIFF
--- a/scrapli/driver/base/base_driver.py
+++ b/scrapli/driver/base/base_driver.py
@@ -14,6 +14,7 @@ from scrapli.logging import get_instance_logger
 from scrapli.ssh_config import ssh_config_factory
 from scrapli.transport import CORE_TRANSPORTS
 from scrapli.transport.base import BasePluginTransportArgs, BaseTransportArgs
+from scrapli.transport.base.base_transport import BaseTransport 
 
 
 class BaseDriver:
@@ -617,12 +618,15 @@ class BaseDriver:
 
         resolved_ssh_config_file = ""
 
-        if Path(ssh_config_file).is_file():
-            resolved_ssh_config_file = str(Path(ssh_config_file))
-        elif Path("~/.ssh/config").expanduser().is_file():
-            resolved_ssh_config_file = str(Path("~/.ssh/config").expanduser())
-        elif Path("/etc/ssh/ssh_config").is_file():
-            resolved_ssh_config_file = str(Path("/etc/ssh/ssh_config"))
+        if ssh_config_file is True and self.transport_name == "system":
+            resolved_ssh_config_file = BaseTransport.SSH_SYSTEM_CONFIG_MAGIC_STRING
+        else:
+            if Path(ssh_config_file).is_file():
+                resolved_ssh_config_file = str(Path(ssh_config_file))
+            elif Path("~/.ssh/config").expanduser().is_file():
+                resolved_ssh_config_file = str(Path("~/.ssh/config").expanduser())
+            elif Path("/etc/ssh/ssh_config").is_file():
+                resolved_ssh_config_file = str(Path("/etc/ssh/ssh_config"))
 
         if resolved_ssh_config_file:
             self.logger.debug(

--- a/scrapli/driver/base/base_driver.py
+++ b/scrapli/driver/base/base_driver.py
@@ -8,11 +8,7 @@ from types import ModuleType
 from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 
 from scrapli.channel.base_channel import BaseChannelArgs
-from scrapli.exceptions import (
-    ScrapliTransportPluginError,
-    ScrapliTypeError,
-    ScrapliValueError,
-)
+from scrapli.exceptions import ScrapliTransportPluginError, ScrapliTypeError, ScrapliValueError
 from scrapli.helper import format_user_warning, resolve_file
 from scrapli.logging import get_instance_logger
 from scrapli.ssh_config import ssh_config_factory
@@ -187,12 +183,10 @@ class BaseDriver:
         self.auth_username = auth_username
         self.auth_password = auth_password
         self.auth_private_key_passphrase = auth_private_key_passphrase
-        self.auth_private_key, self.auth_strict_key, self.auth_bypass = (
-            self._setup_auth(
-                auth_private_key=auth_private_key,
-                auth_strict_key=auth_strict_key,
-                auth_bypass=auth_bypass,
-            )
+        self.auth_private_key, self.auth_strict_key, self.auth_bypass = self._setup_auth(
+            auth_private_key=auth_private_key,
+            auth_strict_key=auth_strict_key,
+            auth_bypass=auth_bypass,
         )
 
         self.ssh_config_file, self.ssh_known_hosts_file = self._setup_ssh_file_args(
@@ -295,9 +289,7 @@ class BaseDriver:
 
         """
         if not host:
-            raise ScrapliValueError(
-                "`host` should be a hostname/ip address, got nothing!"
-            )
+            raise ScrapliValueError("`host` should be a hostname/ip address, got nothing!")
         if not isinstance(port, int):
             raise ScrapliTypeError(f"`port` should be int, got {type(port)}")
 
@@ -327,13 +319,9 @@ class BaseDriver:
 
         """
         if not isinstance(auth_strict_key, bool):
-            raise ScrapliTypeError(
-                f"`auth_strict_key` should be bool, got {type(auth_strict_key)}"
-            )
+            raise ScrapliTypeError(f"`auth_strict_key` should be bool, got {type(auth_strict_key)}")
         if not isinstance(auth_bypass, bool):
-            raise ScrapliTypeError(
-                f"`auth_bypass` should be bool, got {type(auth_bypass)}"
-            )
+            raise ScrapliTypeError(f"`auth_bypass` should be bool, got {type(auth_bypass)}")
 
         if auth_private_key:
             auth_private_key_path = resolve_file(file=auth_private_key)
@@ -367,9 +355,7 @@ class BaseDriver:
 
         """
         if "telnet" in transport:
-            self.logger.debug(
-                "telnet-based transport selected, ignoring ssh file arguments"
-            )
+            self.logger.debug("telnet-based transport selected, ignoring ssh file arguments")
             # the word "telnet" should occur in all telnet drivers, always. so this should be safe!
             return "", ""
 
@@ -379,8 +365,7 @@ class BaseDriver:
             )
         if not isinstance(ssh_known_hosts_file, (str, bool)):
             raise ScrapliTypeError(
-                "`ssh_known_hosts_file` must be str or bool, got "
-                f"{type(ssh_known_hosts_file)}"
+                "`ssh_known_hosts_file` must be str or bool, got " f"{type(ssh_known_hosts_file)}"
             )
 
         if ssh_config_file is not False:
@@ -388,9 +373,7 @@ class BaseDriver:
                 cfg = ""
             else:
                 cfg = ssh_config_file
-            resolved_ssh_config_file = self._resolve_ssh_config(
-                cfg, transport=transport
-            )
+            resolved_ssh_config_file = self._resolve_ssh_config(cfg, transport=transport)
         else:
             resolved_ssh_config_file = ""
 
@@ -474,9 +457,7 @@ class BaseDriver:
         if on_open is not None and not callable(on_open):
             raise ScrapliTypeError(f"`on_open` must be a callable, got {type(on_open)}")
         if on_close is not None and not callable(on_close):
-            raise ScrapliTypeError(
-                f"`on_close` must be a callable, got {type(on_close)}"
-            )
+            raise ScrapliTypeError(f"`on_close` must be a callable, got {type(on_close)}")
 
         self.on_init = on_init
         self.on_open = on_open
@@ -498,17 +479,12 @@ class BaseDriver:
 
         """
         if self.transport_name in CORE_TRANSPORTS:
-            transport_class, _plugin_transport_args_class = (
-                self._load_core_transport_plugin()
-            )
+            transport_class, _plugin_transport_args_class = self._load_core_transport_plugin()
         else:
-            transport_class, _plugin_transport_args_class = (
-                self._load_non_core_transport_plugin()
-            )
+            transport_class, _plugin_transport_args_class = self._load_non_core_transport_plugin()
 
         _plugin_transport_args = {
-            field.name: getattr(self, field.name)
-            for field in fields(_plugin_transport_args_class)
+            field.name: getattr(self, field.name) for field in fields(_plugin_transport_args_class)
         }
 
         # ignore type as we are typing it as the base class to make life simple, because of this
@@ -621,9 +597,7 @@ class BaseDriver:
             transport_plugin_module=transport_plugin_module
         )
 
-        self.logger.debug(
-            f"non-core transport '{self.transport_name}' loaded successfully"
-        )
+        self.logger.debug(f"non-core transport '{self.transport_name}' loaded successfully")
 
         return transport_class, plugin_transport_args
 
@@ -644,9 +618,7 @@ class BaseDriver:
             N/A
 
         """
-        self.logger.debug(
-            f"attempting to resolve 'ssh_config_file' file {ssh_config_file}"
-        )
+        self.logger.debug(f"attempting to resolve 'ssh_config_file' file {ssh_config_file}")
 
         resolved_ssh_config_file = ""
 
@@ -941,9 +913,7 @@ class BaseDriver:
             raise ScrapliTypeError
 
         if value == 0:
-            self.logger.debug(
-                "'timeout_transport' value is 0, this will disable timeout decorator"
-            )
+            self.logger.debug("'timeout_transport' value is 0, this will disable timeout decorator")
 
         self._base_transport_args.timeout_transport = value
 
@@ -990,9 +960,7 @@ class BaseDriver:
             raise ScrapliTypeError
 
         if value == 0:
-            self.logger.debug(
-                "'timeout_ops' value is 0, this will disable timeout decorator"
-            )
+            self.logger.debug("'timeout_ops' value is 0, this will disable timeout decorator")
 
         self._base_channel_args.timeout_ops = value
 
@@ -1029,9 +997,7 @@ class BaseDriver:
         """
         operation = "closing" if closing else "opening"
 
-        self.logger.info(
-            f"{operation} connection to '{self.host}' on port '{self.port}'"
-        )
+        self.logger.info(f"{operation} connection to '{self.host}' on port '{self.port}'")
 
     def _post_open_closing_log(self, closing: bool = False) -> None:
         """

--- a/scrapli/driver/base/base_driver.py
+++ b/scrapli/driver/base/base_driver.py
@@ -8,13 +8,17 @@ from types import ModuleType
 from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 
 from scrapli.channel.base_channel import BaseChannelArgs
-from scrapli.exceptions import ScrapliTransportPluginError, ScrapliTypeError, ScrapliValueError
+from scrapli.exceptions import (
+    ScrapliTransportPluginError,
+    ScrapliTypeError,
+    ScrapliValueError,
+)
 from scrapli.helper import format_user_warning, resolve_file
 from scrapli.logging import get_instance_logger
 from scrapli.ssh_config import ssh_config_factory
 from scrapli.transport import CORE_TRANSPORTS
 from scrapli.transport.base import BasePluginTransportArgs, BaseTransportArgs
-from scrapli.transport.base.base_transport import BaseTransport 
+from scrapli.transport.base.base_transport import BaseTransport
 
 
 class BaseDriver:
@@ -183,10 +187,12 @@ class BaseDriver:
         self.auth_username = auth_username
         self.auth_password = auth_password
         self.auth_private_key_passphrase = auth_private_key_passphrase
-        self.auth_private_key, self.auth_strict_key, self.auth_bypass = self._setup_auth(
-            auth_private_key=auth_private_key,
-            auth_strict_key=auth_strict_key,
-            auth_bypass=auth_bypass,
+        self.auth_private_key, self.auth_strict_key, self.auth_bypass = (
+            self._setup_auth(
+                auth_private_key=auth_private_key,
+                auth_strict_key=auth_strict_key,
+                auth_bypass=auth_bypass,
+            )
         )
 
         self.ssh_config_file, self.ssh_known_hosts_file = self._setup_ssh_file_args(
@@ -289,7 +295,9 @@ class BaseDriver:
 
         """
         if not host:
-            raise ScrapliValueError("`host` should be a hostname/ip address, got nothing!")
+            raise ScrapliValueError(
+                "`host` should be a hostname/ip address, got nothing!"
+            )
         if not isinstance(port, int):
             raise ScrapliTypeError(f"`port` should be int, got {type(port)}")
 
@@ -319,9 +327,13 @@ class BaseDriver:
 
         """
         if not isinstance(auth_strict_key, bool):
-            raise ScrapliTypeError(f"`auth_strict_key` should be bool, got {type(auth_strict_key)}")
+            raise ScrapliTypeError(
+                f"`auth_strict_key` should be bool, got {type(auth_strict_key)}"
+            )
         if not isinstance(auth_bypass, bool):
-            raise ScrapliTypeError(f"`auth_bypass` should be bool, got {type(auth_bypass)}")
+            raise ScrapliTypeError(
+                f"`auth_bypass` should be bool, got {type(auth_bypass)}"
+            )
 
         if auth_private_key:
             auth_private_key_path = resolve_file(file=auth_private_key)
@@ -355,7 +367,9 @@ class BaseDriver:
 
         """
         if "telnet" in transport:
-            self.logger.debug("telnet-based transport selected, ignoring ssh file arguments")
+            self.logger.debug(
+                "telnet-based transport selected, ignoring ssh file arguments"
+            )
             # the word "telnet" should occur in all telnet drivers, always. so this should be safe!
             return "", ""
 
@@ -365,7 +379,8 @@ class BaseDriver:
             )
         if not isinstance(ssh_known_hosts_file, (str, bool)):
             raise ScrapliTypeError(
-                "`ssh_known_hosts_file` must be str or bool, got " f"{type(ssh_known_hosts_file)}"
+                "`ssh_known_hosts_file` must be str or bool, got "
+                f"{type(ssh_known_hosts_file)}"
             )
 
         if ssh_config_file is not False:
@@ -373,7 +388,9 @@ class BaseDriver:
                 cfg = ""
             else:
                 cfg = ssh_config_file
-            resolved_ssh_config_file = self._resolve_ssh_config(cfg)
+            resolved_ssh_config_file = self._resolve_ssh_config(
+                cfg, transport=transport
+            )
         else:
             resolved_ssh_config_file = ""
 
@@ -382,7 +399,9 @@ class BaseDriver:
                 known_hosts = ""
             else:
                 known_hosts = ssh_known_hosts_file
-            resolved_ssh_known_hosts_file = self._resolve_ssh_known_hosts(known_hosts)
+            resolved_ssh_known_hosts_file = self._resolve_ssh_known_hosts(
+                known_hosts, transport=transport
+            )
         else:
             resolved_ssh_known_hosts_file = ""
 
@@ -455,7 +474,9 @@ class BaseDriver:
         if on_open is not None and not callable(on_open):
             raise ScrapliTypeError(f"`on_open` must be a callable, got {type(on_open)}")
         if on_close is not None and not callable(on_close):
-            raise ScrapliTypeError(f"`on_close` must be a callable, got {type(on_close)}")
+            raise ScrapliTypeError(
+                f"`on_close` must be a callable, got {type(on_close)}"
+            )
 
         self.on_init = on_init
         self.on_open = on_open
@@ -477,12 +498,17 @@ class BaseDriver:
 
         """
         if self.transport_name in CORE_TRANSPORTS:
-            transport_class, _plugin_transport_args_class = self._load_core_transport_plugin()
+            transport_class, _plugin_transport_args_class = (
+                self._load_core_transport_plugin()
+            )
         else:
-            transport_class, _plugin_transport_args_class = self._load_non_core_transport_plugin()
+            transport_class, _plugin_transport_args_class = (
+                self._load_non_core_transport_plugin()
+            )
 
         _plugin_transport_args = {
-            field.name: getattr(self, field.name) for field in fields(_plugin_transport_args_class)
+            field.name: getattr(self, field.name)
+            for field in fields(_plugin_transport_args_class)
         }
 
         # ignore type as we are typing it as the base class to make life simple, because of this
@@ -558,7 +584,9 @@ class BaseDriver:
 
         return transport_class, plugin_transport_args
 
-    def _load_non_core_transport_plugin(self) -> Tuple[Any, Type[BasePluginTransportArgs]]:
+    def _load_non_core_transport_plugin(
+        self,
+    ) -> Tuple[Any, Type[BasePluginTransportArgs]]:
         """
         Find non-core transport plugins and required plugin arguments
 
@@ -593,11 +621,13 @@ class BaseDriver:
             transport_plugin_module=transport_plugin_module
         )
 
-        self.logger.debug(f"non-core transport '{self.transport_name}' loaded successfully")
+        self.logger.debug(
+            f"non-core transport '{self.transport_name}' loaded successfully"
+        )
 
         return transport_class, plugin_transport_args
 
-    def _resolve_ssh_config(self, ssh_config_file: str) -> str:
+    def _resolve_ssh_config(self, ssh_config_file: str, transport: str) -> str:
         """
         Resolve ssh configuration file from provided string
 
@@ -614,11 +644,13 @@ class BaseDriver:
             N/A
 
         """
-        self.logger.debug("attempting to resolve 'ssh_config_file' file")
+        self.logger.debug(
+            f"attempting to resolve 'ssh_config_file' file {ssh_config_file}"
+        )
 
         resolved_ssh_config_file = ""
 
-        if ssh_config_file is True and self.transport_name == "system":
+        if ssh_config_file == "" and transport == "system":
             resolved_ssh_config_file = BaseTransport.SSH_SYSTEM_CONFIG_MAGIC_STRING
         else:
             if Path(ssh_config_file).is_file():
@@ -637,7 +669,7 @@ class BaseDriver:
 
         return resolved_ssh_config_file
 
-    def _resolve_ssh_known_hosts(self, ssh_known_hosts: str) -> str:
+    def _resolve_ssh_known_hosts(self, ssh_known_hosts: str, transport: str) -> str:
         """
         Resolve ssh known hosts file from provided string
 
@@ -657,13 +689,15 @@ class BaseDriver:
         self.logger.debug("attempting to resolve 'ssh_known_hosts file'")
 
         resolved_ssh_known_hosts = ""
-
-        if Path(ssh_known_hosts).is_file():
-            resolved_ssh_known_hosts = str(Path(ssh_known_hosts))
-        elif Path("~/.ssh/known_hosts").expanduser().is_file():
-            resolved_ssh_known_hosts = str(Path("~/.ssh/known_hosts").expanduser())
-        elif Path("/etc/ssh/ssh_known_hosts").is_file():
-            resolved_ssh_known_hosts = str(Path("/etc/ssh/ssh_known_hosts"))
+        if ssh_known_hosts == "" and transport == "system":
+            resolved_ssh_known_hosts = BaseTransport.SSH_SYSTEM_CONFIG_MAGIC_STRING
+        else:
+            if Path(ssh_known_hosts).is_file():
+                resolved_ssh_known_hosts = str(Path(ssh_known_hosts))
+            elif Path("~/.ssh/known_hosts").expanduser().is_file():
+                resolved_ssh_known_hosts = str(Path("~/.ssh/known_hosts").expanduser())
+            elif Path("/etc/ssh/ssh_known_hosts").is_file():
+                resolved_ssh_known_hosts = str(Path("/etc/ssh/ssh_known_hosts"))
 
         if resolved_ssh_known_hosts:
             self.logger.debug(
@@ -907,7 +941,9 @@ class BaseDriver:
             raise ScrapliTypeError
 
         if value == 0:
-            self.logger.debug("'timeout_transport' value is 0, this will disable timeout decorator")
+            self.logger.debug(
+                "'timeout_transport' value is 0, this will disable timeout decorator"
+            )
 
         self._base_transport_args.timeout_transport = value
 
@@ -954,7 +990,9 @@ class BaseDriver:
             raise ScrapliTypeError
 
         if value == 0:
-            self.logger.debug("'timeout_ops' value is 0, this will disable timeout decorator")
+            self.logger.debug(
+                "'timeout_ops' value is 0, this will disable timeout decorator"
+            )
 
         self._base_channel_args.timeout_ops = value
 
@@ -991,7 +1029,9 @@ class BaseDriver:
         """
         operation = "closing" if closing else "opening"
 
-        self.logger.info(f"{operation} connection to '{self.host}' on port '{self.port}'")
+        self.logger.info(
+            f"{operation} connection to '{self.host}' on port '{self.port}'"
+        )
 
     def _post_open_closing_log(self, closing: bool = False) -> None:
         """

--- a/scrapli/transport/base/base_transport.py
+++ b/scrapli/transport/base/base_transport.py
@@ -23,7 +23,6 @@ class BasePluginTransportArgs:
 
 
 class BaseTransport(ABC):
-    SSH_SYSTEM_CONFIG_MAGIC_STRING: str = "__SCRAPLI_RULES__"
 
     def __init__(self, base_transport_args: BaseTransportArgs) -> None:
         """

--- a/scrapli/transport/base/base_transport.py
+++ b/scrapli/transport/base/base_transport.py
@@ -24,6 +24,7 @@ class BasePluginTransportArgs:
 
 class BaseTransport(ABC):
     SSH_SYSTEM_CONFIG_MAGIC_STRING: str = "__SCRAPLI_RULES__"
+
     def __init__(self, base_transport_args: BaseTransportArgs) -> None:
         """
         Scrapli's transport base class

--- a/scrapli/transport/base/base_transport.py
+++ b/scrapli/transport/base/base_transport.py
@@ -23,6 +23,7 @@ class BasePluginTransportArgs:
 
 
 class BaseTransport(ABC):
+    SSH_SYSTEM_CONFIG_MAGIC_STRING: str = "__SCRAPLI_RULES__"
     def __init__(self, base_transport_args: BaseTransportArgs) -> None:
         """
         Scrapli's transport base class

--- a/scrapli/transport/plugins/system/transport.py
+++ b/scrapli/transport/plugins/system/transport.py
@@ -101,9 +101,15 @@ class SystemTransport(Transport):
         else:
             self.open_cmd.extend(["-o", "StrictHostKeyChecking=yes"])
             if self.plugin_transport_args.ssh_known_hosts_file:
-                self.open_cmd.extend(
-                    ["-o", f"UserKnownHostsFile={self.plugin_transport_args.ssh_known_hosts_file}"]
-                )
+                if self.plugin_transport_args.ssh_known_hosts_file == self.SSH_SYSTEM_CONFIG_MAGIC_STRING:
+                    self.logger.debug(
+                        "Using system transport and ssh_known_hosts_file is True, not specifying any "
+                        "known_hosts file"
+                    )
+                else:
+                    self.open_cmd.extend(
+                        ["-o", f"UserKnownHostsFile={self.plugin_transport_args.ssh_known_hosts_file}"]
+                    )
 
         if self.plugin_transport_args.ssh_config_file == self.SSH_SYSTEM_CONFIG_MAGIC_STRING:
             self.logger.debug("Using system transport and ssh_config is True, not specifying any SSH config")

--- a/scrapli/transport/plugins/system/transport.py
+++ b/scrapli/transport/plugins/system/transport.py
@@ -101,18 +101,26 @@ class SystemTransport(Transport):
         else:
             self.open_cmd.extend(["-o", "StrictHostKeyChecking=yes"])
             if self.plugin_transport_args.ssh_known_hosts_file:
-                if self.plugin_transport_args.ssh_known_hosts_file == self.SSH_SYSTEM_CONFIG_MAGIC_STRING:
+                if (
+                    self.plugin_transport_args.ssh_known_hosts_file
+                    == self.SSH_SYSTEM_CONFIG_MAGIC_STRING
+                ):
                     self.logger.debug(
                         "Using system transport and ssh_known_hosts_file is True, not specifying any "
                         "known_hosts file"
                     )
                 else:
                     self.open_cmd.extend(
-                        ["-o", f"UserKnownHostsFile={self.plugin_transport_args.ssh_known_hosts_file}"]
+                        [
+                            "-o",
+                            f"UserKnownHostsFile={self.plugin_transport_args.ssh_known_hosts_file}",
+                        ]
                     )
 
         if self.plugin_transport_args.ssh_config_file == self.SSH_SYSTEM_CONFIG_MAGIC_STRING:
-            self.logger.debug("Using system transport and ssh_config is True, not specifying any SSH config")
+            self.logger.debug(
+                "Using system transport and ssh_config is True, not specifying any SSH config"
+            )
         else:
             if self.plugin_transport_args.ssh_config_file:
                 self.open_cmd.extend(["-F", self.plugin_transport_args.ssh_config_file])

--- a/scrapli/transport/plugins/system/transport.py
+++ b/scrapli/transport/plugins/system/transport.py
@@ -105,10 +105,13 @@ class SystemTransport(Transport):
                     ["-o", f"UserKnownHostsFile={self.plugin_transport_args.ssh_known_hosts_file}"]
                 )
 
-        if self.plugin_transport_args.ssh_config_file:
-            self.open_cmd.extend(["-F", self.plugin_transport_args.ssh_config_file])
+        if self.plugin_transport_args.ssh_config_file == self.SSH_SYSTEM_CONFIG_MAGIC_STRING:
+            self.logger.debug("Using system transport and ssh_config is True, not specifying any SSH config")
         else:
-            self.open_cmd.extend(["-F", "/dev/null"])
+            if self.plugin_transport_args.ssh_config_file:
+                self.open_cmd.extend(["-F", self.plugin_transport_args.ssh_config_file])
+            else:
+                self.open_cmd.extend(["-F", "/dev/null"])
 
         open_cmd_user_args = self._base_transport_args.transport_options.get("open_cmd", [])
         if isinstance(open_cmd_user_args, str):

--- a/scrapli/transport/plugins/system/transport.py
+++ b/scrapli/transport/plugins/system/transport.py
@@ -24,6 +24,9 @@ class PluginTransportArgs(BasePluginTransportArgs):
 
 
 class SystemTransport(Transport):
+    SSH_SYSTEM_CONFIG_MAGIC_STRING: str = "SYSTEM_TRANSPORT_SSH_CONFIG_TRUE"
+    SSH_SYSTEM_KNOWN_HOSTS_FILE_MAGIC_STRING: str = "SYSTEM_TRANSPORT_KNOWN_HOSTS_TRUE"
+
     def __init__(
         self, base_transport_args: BaseTransportArgs, plugin_transport_args: PluginTransportArgs
     ) -> None:
@@ -100,32 +103,32 @@ class SystemTransport(Transport):
             self.open_cmd.extend(["-o", "UserKnownHostsFile=/dev/null"])
         else:
             self.open_cmd.extend(["-o", "StrictHostKeyChecking=yes"])
-            if self.plugin_transport_args.ssh_known_hosts_file:
-                if (
-                    self.plugin_transport_args.ssh_known_hosts_file
-                    == self.SSH_SYSTEM_CONFIG_MAGIC_STRING
-                ):
-                    self.logger.debug(
-                        "Using system transport and ssh_known_hosts_file is True, not specifying any "
-                        "known_hosts file"
-                    )
-                else:
-                    self.open_cmd.extend(
-                        [
-                            "-o",
-                            f"UserKnownHostsFile={self.plugin_transport_args.ssh_known_hosts_file}",
-                        ]
-                    )
 
-        if self.plugin_transport_args.ssh_config_file == self.SSH_SYSTEM_CONFIG_MAGIC_STRING:
+            if (
+                self.plugin_transport_args.ssh_known_hosts_file
+                == self.SSH_SYSTEM_KNOWN_HOSTS_FILE_MAGIC_STRING
+            ):
+                self.logger.debug(
+                    "Using system transport and ssh_known_hosts_file is True, not specifying any "
+                    "known_hosts file"
+                )
+            elif self.plugin_transport_args.ssh_known_hosts_file:
+                self.open_cmd.extend(
+                    [
+                        "-o",
+                        f"UserKnownHostsFile={self.plugin_transport_args.ssh_known_hosts_file}",
+                    ]
+                )
+            else:
+                self.logger.debug("No known hosts file specified")
+        if not self.plugin_transport_args.ssh_config_file:
+            self.open_cmd.extend(["-F", "/dev/null"])
+        elif self.plugin_transport_args.ssh_config_file == self.SSH_SYSTEM_CONFIG_MAGIC_STRING:
             self.logger.debug(
                 "Using system transport and ssh_config is True, not specifying any SSH config"
             )
         else:
-            if self.plugin_transport_args.ssh_config_file:
-                self.open_cmd.extend(["-F", self.plugin_transport_args.ssh_config_file])
-            else:
-                self.open_cmd.extend(["-F", "/dev/null"])
+            self.open_cmd.extend(["-F", self.plugin_transport_args.ssh_config_file])
 
         open_cmd_user_args = self._base_transport_args.transport_options.get("open_cmd", [])
         if isinstance(open_cmd_user_args, str):

--- a/tests/unit/driver/base/test_base_base_driver.py
+++ b/tests/unit/driver/base/test_base_base_driver.py
@@ -14,6 +14,7 @@ from scrapli.transport.base import (
     BaseTransportArgs,
     Transport,
 )
+from scrapli.transport.plugins.system.transport import SystemTransport
 
 
 @dataclass
@@ -207,8 +208,8 @@ def test_update_ssh_args_from_ssh_config(fs_, real_ssh_config_file_path, base_dr
         (
             True,
             True,
-            Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
-            Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
+            SystemTransport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
+            SystemTransport.SSH_SYSTEM_KNOWN_HOSTS_FILE_MAGIC_STRING,
             "system",
         ),
         (True, True, "", "", "asyncssh"),
@@ -352,14 +353,14 @@ def test_transport_factory_non_core(monkeypatch, test_data):
 @pytest.mark.parametrize(
     "test_data",
     [
-        ("system", "", Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING, True, "/etc/ssh/ssh_config"),
+        ("system", "", SystemTransport.SSH_SYSTEM_CONFIG_MAGIC_STRING, True, "/etc/ssh/ssh_config"),
         ("asyncssh", "", "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
         ("system", "/etc/ssh/ssh_config", "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
         ("ssh2", "/etc/ssh/ssh_config", "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
         (
             "system",
             "",
-            Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
+            SystemTransport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
             True,
             str(Path("~/.ssh/config").expanduser()),
         ),
@@ -402,12 +403,18 @@ def test_resolve_ssh_config(fs_, real_ssh_config_file_path, base_driver, test_da
 @pytest.mark.parametrize(
     "test_data",
     [
-        ("system", "", Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING, True, "/etc/ssh/ssh_known_hosts"),
+        (
+            "system",
+            "",
+            SystemTransport.SSH_SYSTEM_KNOWN_HOSTS_FILE_MAGIC_STRING,
+            True,
+            "/etc/ssh/ssh_known_hosts",
+        ),
         ("asyncssh", "", "/etc/ssh/ssh_known_hosts", True, "/etc/ssh/ssh_known_hosts"),
         (
             "system",
             "",
-            Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
+            SystemTransport.SSH_SYSTEM_KNOWN_HOSTS_FILE_MAGIC_STRING,
             True,
             str(Path("~/.ssh/known_hosts").expanduser()),
         ),
@@ -425,7 +432,7 @@ def test_resolve_ssh_config(fs_, real_ssh_config_file_path, base_driver, test_da
             True,
             "/non_standard_ssh_known_hosts",
         ),
-        ("system", "", Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING, False, ""),
+        ("system", "", SystemTransport.SSH_SYSTEM_KNOWN_HOSTS_FILE_MAGIC_STRING, False, ""),
         ("ssh2", "", "", False, ""),
     ],
     ids=(

--- a/tests/unit/driver/base/test_base_base_driver.py
+++ b/tests/unit/driver/base/test_base_base_driver.py
@@ -209,31 +209,13 @@ def test_update_ssh_args_from_ssh_config(fs_, real_ssh_config_file_path, base_dr
             True,
             Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
             Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
-            "system"            
+            "system",
         ),
-        (
-            True,
-            True,
-            "",
-            "",
-            "asyncssh"            
-        ),
-        (
-            "blah",
-            "blah",
-            "",
-            "",
-            "system"
-        ),
-        (
-            "blah",
-            "blah",
-            "",
-            "",
-            "asyncssh"
-        ),
+        (True, True, "", "", "asyncssh"),
+        ("blah", "blah", "", "", "system"),
+        ("blah", "blah", "", "", "asyncssh"),
     ),
-    ids=("true-system", "true-asyncssh","unresolvable_path-system", "unresolvable_path-asyncssh"),
+    ids=("true-system", "true-asyncssh", "unresolvable_path-system", "unresolvable_path-asyncssh"),
 )
 def test_setup_ssh_file_args_resolved(fs_, test_data, base_driver):
     """
@@ -243,7 +225,13 @@ def test_setup_ssh_file_args_resolved(fs_, test_data, base_driver):
     that if given a non False bool or a string we properly try to resolve the ssh files
     """
     # using fakefs to ensure we dont resolve user/system config files
-    ssh_config_file_input, ssh_known_hosts_file_input, expected_result_ssh_config, expected_result_known_hosts, transport = test_data
+    (
+        ssh_config_file_input,
+        ssh_known_hosts_file_input,
+        expected_result_ssh_config,
+        expected_result_known_hosts,
+        transport,
+    ) = test_data
     resolved_ssh_config_file, resolved_ssh_known_hosts_file = base_driver._setup_ssh_file_args(
         transport=transport,
         ssh_config_file=ssh_config_file_input,
@@ -365,27 +353,42 @@ def test_transport_factory_non_core(monkeypatch, test_data):
     "test_data",
     [
         ("system", "", Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING, True, "/etc/ssh/ssh_config"),
-        ("asyncssh", "",  "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
+        ("asyncssh", "", "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
         ("system", "/etc/ssh/ssh_config", "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
         ("ssh2", "/etc/ssh/ssh_config", "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
-        (   
+        (
             "system",
             "",
             Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
             True,
             str(Path("~/.ssh/config").expanduser()),
         ),
-        (   
+        (
             "ssh2",
             "",
             str(Path("~/.ssh/config").expanduser()),
             True,
             str(Path("~/.ssh/config").expanduser()),
         ),
-        ("system", "/non_standard_ssh_config", "/non_standard_ssh_config", True, "/non_standard_ssh_config"),
-        ("ssh2","", "", False, ""),
+        (
+            "system",
+            "/non_standard_ssh_config",
+            "/non_standard_ssh_config",
+            True,
+            "/non_standard_ssh_config",
+        ),
+        ("ssh2", "", "", False, ""),
     ],
-    ids=("auto_etc-system", "auto_etc-asyncssh", "manual_location-system", "manual_location-ssh2", "auto_user-system", "auto_user-ssh2", "non-standard", "no_config-ssh2"),
+    ids=(
+        "auto_etc-system",
+        "auto_etc-asyncssh",
+        "manual_location-system",
+        "manual_location-ssh2",
+        "auto_user-system",
+        "auto_user-ssh2",
+        "non-standard",
+        "no_config-ssh2",
+    ),
 )
 def test_resolve_ssh_config(fs_, real_ssh_config_file_path, base_driver, test_data):
 
@@ -425,7 +428,15 @@ def test_resolve_ssh_config(fs_, real_ssh_config_file_path, base_driver, test_da
         ("system", "", Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING, False, ""),
         ("ssh2", "", "", False, ""),
     ],
-    ids=("auto_etc-system", "auto_etc-asyncssh", "auto_user-system", "auto_user-asyncssh", "manual_location", "no_config-system", "no_config-ssh2"),
+    ids=(
+        "auto_etc-system",
+        "auto_etc-asyncssh",
+        "auto_user-system",
+        "auto_user-asyncssh",
+        "manual_location",
+        "no_config-system",
+        "no_config-ssh2",
+    ),
 )
 def test_resolve_ssh_known_hosts(fs_, real_ssh_known_hosts_file_path, base_driver, test_data):
     transport, input_data, expected_output, mount_real_file, fake_fs_destination = test_data
@@ -433,7 +444,9 @@ def test_resolve_ssh_known_hosts(fs_, real_ssh_known_hosts_file_path, base_drive
         fs_.add_real_file(
             source_path=real_ssh_known_hosts_file_path, target_path=fake_fs_destination
         )
-    actual_output = base_driver._resolve_ssh_known_hosts(ssh_known_hosts=input_data, transport=transport)
+    actual_output = base_driver._resolve_ssh_known_hosts(
+        ssh_known_hosts=input_data, transport=transport
+    )
     assert actual_output == expected_output
 
 

--- a/tests/unit/driver/base/test_base_base_driver.py
+++ b/tests/unit/driver/base/test_base_base_driver.py
@@ -207,15 +207,35 @@ def test_update_ssh_args_from_ssh_config(fs_, real_ssh_config_file_path, base_dr
         (
             True,
             True,
+            Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
+            Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
+            "system"            
+        ),
+        (
+            True,
+            True,
+            "",
+            "",
+            "asyncssh"            
         ),
         (
             "blah",
             "blah",
+            "",
+            "",
+            "system"
+        ),
+        (
+            "blah",
+            "blah",
+            "",
+            "",
+            "asyncssh"
         ),
     ),
-    ids=("true", "unresolvable_path"),
+    ids=("true-system", "true-asyncssh","unresolvable_path-system", "unresolvable_path-asyncssh"),
 )
-def test_setup_ssh_file_args_resolved(fs_, base_driver, test_data):
+def test_setup_ssh_file_args_resolved(fs_, test_data, base_driver):
     """
     Assert we handle ssh config/known hosts inputs properly
 
@@ -223,16 +243,15 @@ def test_setup_ssh_file_args_resolved(fs_, base_driver, test_data):
     that if given a non False bool or a string we properly try to resolve the ssh files
     """
     # using fakefs to ensure we dont resolve user/system config files
-    ssh_config_file_input, ssh_known_hosts_file_input = test_data
-
+    ssh_config_file_input, ssh_known_hosts_file_input, expected_result_ssh_config, expected_result_known_hosts, transport = test_data
     resolved_ssh_config_file, resolved_ssh_known_hosts_file = base_driver._setup_ssh_file_args(
-        transport="system",
+        transport=transport,
         ssh_config_file=ssh_config_file_input,
         ssh_known_hosts_file=ssh_known_hosts_file_input,
     )
 
-    assert resolved_ssh_config_file == ""
-    assert resolved_ssh_known_hosts_file == ""
+    assert resolved_ssh_config_file == expected_result_ssh_config
+    assert resolved_ssh_known_hosts_file == expected_result_known_hosts
 
 
 @pytest.mark.parametrize(
@@ -345,55 +364,76 @@ def test_transport_factory_non_core(monkeypatch, test_data):
 @pytest.mark.parametrize(
     "test_data",
     [
-        ("", "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
-        (
+        ("system", "", Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING, True, "/etc/ssh/ssh_config"),
+        ("asyncssh", "",  "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
+        ("system", "/etc/ssh/ssh_config", "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
+        ("ssh2", "/etc/ssh/ssh_config", "/etc/ssh/ssh_config", True, "/etc/ssh/ssh_config"),
+        (   
+            "system",
+            "",
+            Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
+            True,
+            str(Path("~/.ssh/config").expanduser()),
+        ),
+        (   
+            "ssh2",
             "",
             str(Path("~/.ssh/config").expanduser()),
             True,
             str(Path("~/.ssh/config").expanduser()),
         ),
-        ("/non_standard_ssh_config", "/non_standard_ssh_config", True, "/non_standard_ssh_config"),
-        ("", "", False, ""),
+        ("system", "/non_standard_ssh_config", "/non_standard_ssh_config", True, "/non_standard_ssh_config"),
+        ("ssh2","", "", False, ""),
     ],
-    ids=("auto_etc", "auto_user", "manual_location", "no_config"),
+    ids=("auto_etc-system", "auto_etc-asyncssh", "manual_location-system", "manual_location-ssh2", "auto_user-system", "auto_user-ssh2", "non-standard", "no_config-ssh2"),
 )
 def test_resolve_ssh_config(fs_, real_ssh_config_file_path, base_driver, test_data):
-    input_data, expected_output, mount_real_file, fake_fs_destination = test_data
 
+    transport, input_data, expected_output, mount_real_file, fake_fs_destination = test_data
     if mount_real_file:
         fs_.add_real_file(source_path=real_ssh_config_file_path, target_path=fake_fs_destination)
-    actual_output = base_driver._resolve_ssh_config(ssh_config_file=input_data)
+    actual_output = base_driver._resolve_ssh_config(ssh_config_file=input_data, transport=transport)
     assert actual_output == expected_output
 
 
 @pytest.mark.parametrize(
     "test_data",
     [
-        ("", "/etc/ssh/ssh_known_hosts", True, "/etc/ssh/ssh_known_hosts"),
+        ("system", "", Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING, True, "/etc/ssh/ssh_known_hosts"),
+        ("asyncssh", "", "/etc/ssh/ssh_known_hosts", True, "/etc/ssh/ssh_known_hosts"),
         (
+            "system",
+            "",
+            Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING,
+            True,
+            str(Path("~/.ssh/known_hosts").expanduser()),
+        ),
+        (
+            "asyncssh",
             "",
             str(Path("~/.ssh/known_hosts").expanduser()),
             True,
             str(Path("~/.ssh/known_hosts").expanduser()),
         ),
         (
+            "system",
             "/non_standard_ssh_known_hosts",
             "/non_standard_ssh_known_hosts",
             True,
             "/non_standard_ssh_known_hosts",
         ),
-        ("", "", False, ""),
+        ("system", "", Transport.SSH_SYSTEM_CONFIG_MAGIC_STRING, False, ""),
+        ("ssh2", "", "", False, ""),
     ],
-    ids=("auto_etc", "auto_user", "manual_location", "no_config"),
+    ids=("auto_etc-system", "auto_etc-asyncssh", "auto_user-system", "auto_user-asyncssh", "manual_location", "no_config-system", "no_config-ssh2"),
 )
 def test_resolve_ssh_known_hosts(fs_, real_ssh_known_hosts_file_path, base_driver, test_data):
-    input_data, expected_output, mount_real_file, fake_fs_destination = test_data
-
+    transport, input_data, expected_output, mount_real_file, fake_fs_destination = test_data
     if mount_real_file:
         fs_.add_real_file(
             source_path=real_ssh_known_hosts_file_path, target_path=fake_fs_destination
         )
-    actual_output = base_driver._resolve_ssh_known_hosts(ssh_known_hosts=input_data)
+    actual_output = base_driver._resolve_ssh_known_hosts(ssh_known_hosts=input_data, transport=transport)
     assert actual_output == expected_output
 
 


### PR DESCRIPTION
# Description

See issue  #336, when passing True to the ssh_config_file and using the system transport, you now effectively get the same behaviour as the regular ssh client (no -F args are passed). That means that **both** the user and the system ssh config are respected. I also implemented the same change for the known_hosts_file.


## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Added necessary tests in test_base_base_driver.py, did a real-world test against a device

# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
