### PR TITLE
Adding lazy logging along critical path

### DIFF
--- a/scrapli/channel/async_channel.py
+++ b/scrapli/channel/async_channel.py
@@ -664,7 +664,7 @@ class AsyncChannel(BaseChannel):
 
                 _channel_input = channel_input if not hidden_input else "REDACTED"
                 self.logger.info(
-                    "sending interactive input: %s; " "expecting: %s; " "hidden_input: %s",
+                    "sending interactive input: %s; expecting: %s; hidden_input: %s",
                     _channel_input,
                     channel_response,
                     hidden_input,

--- a/scrapli/channel/async_channel.py
+++ b/scrapli/channel/async_channel.py
@@ -492,7 +492,9 @@ class AsyncChannel(BaseChannel):
 
         self.logger.info(
             "sending channel input: %s; strip_prompt: %s; eager: %s",
-            channel_input, strip_prompt, eager
+            channel_input,
+            strip_prompt,
+            eager,
         )
 
         async with self._channel_lock():
@@ -549,7 +551,10 @@ class AsyncChannel(BaseChannel):
         self.logger.info(
             "sending channel input and read: %s; strip_prompt: %s; "
             "expected_outputs: %s; read_duration: %s",
-            channel_input, strip_prompt, expected_outputs, read_duration
+            channel_input,
+            strip_prompt,
+            expected_outputs,
+            read_duration,
         )
 
         async with self._channel_lock():
@@ -659,10 +664,10 @@ class AsyncChannel(BaseChannel):
 
                 _channel_input = channel_input if not hidden_input else "REDACTED"
                 self.logger.info(
-                    "sending interactive input: %s; "
-                    "expecting: %s; "
-                    "hidden_input: %s",
-                    _channel_input, channel_response, hidden_input
+                    "sending interactive input: %s; " "expecting: %s; " "hidden_input: %s",
+                    _channel_input,
+                    channel_response,
+                    hidden_input,
                 )
 
                 self.write(channel_input=channel_input, redacted=bool(hidden_input))

--- a/scrapli/channel/async_channel.py
+++ b/scrapli/channel/async_channel.py
@@ -71,7 +71,7 @@ class AsyncChannel(BaseChannel):
         buf = await self.transport.read()
         buf = buf.replace(b"\r", b"")
 
-        self.logger.debug(f"read: {buf!r}")
+        self.logger.debug("read: %r", buf)
 
         if self.channel_log:
             self.channel_log.write(buf)
@@ -491,7 +491,8 @@ class AsyncChannel(BaseChannel):
         bytes_channel_input = channel_input.encode()
 
         self.logger.info(
-            f"sending channel input: {channel_input}; strip_prompt: {strip_prompt}; eager: {eager}"
+            "sending channel input: %s; strip_prompt: %s; eager: %s",
+            channel_input, strip_prompt, eager
         )
 
         async with self._channel_lock():
@@ -546,8 +547,9 @@ class AsyncChannel(BaseChannel):
         ]
 
         self.logger.info(
-            f"sending channel input and read: {channel_input}; strip_prompt: {strip_prompt}; "
-            f"expected_outputs: {expected_outputs}; read_duration: {read_duration}"
+            "sending channel input and read: %s; strip_prompt: %s; "
+            "expected_outputs: %s; read_duration: %s",
+            channel_input, strip_prompt, expected_outputs, read_duration
         )
 
         async with self._channel_lock():
@@ -657,9 +659,10 @@ class AsyncChannel(BaseChannel):
 
                 _channel_input = channel_input if not hidden_input else "REDACTED"
                 self.logger.info(
-                    f"sending interactive input: {_channel_input}; "
-                    f"expecting: {channel_response}; "
-                    f"hidden_input: {hidden_input}"
+                    "sending interactive input: %s; "
+                    "expecting: %s; "
+                    "hidden_input: %s",
+                    _channel_input, channel_response, hidden_input
                 )
 
                 self.write(channel_input=channel_input, redacted=bool(hidden_input))

--- a/scrapli/channel/base_channel.py
+++ b/scrapli/channel/base_channel.py
@@ -368,8 +368,10 @@ class BaseChannel:
             N/A
 
         """
-        log_output = "REDACTED" if redacted else repr(channel_input)
-        self.logger.debug(f"write: {log_output}")
+        if redacted:
+            self.logger.debug("write: REDACTED")
+        else:
+            self.logger.debug("write: %r", channel_input)
 
         self.transport.write(channel_input=channel_input.encode())
 

--- a/scrapli/channel/sync_channel.py
+++ b/scrapli/channel/sync_channel.py
@@ -665,7 +665,7 @@ class Channel(BaseChannel):
 
                 _channel_input = channel_input if not hidden_input else "REDACTED"
                 self.logger.info(
-                    "sending interactive input: %s; " "expecting: %s; " "hidden_input: %s",
+                    "sending interactive input: %s; expecting: %s; hidden_input: %s",
                     _channel_input,
                     channel_response,
                     hidden_input,

--- a/scrapli/channel/sync_channel.py
+++ b/scrapli/channel/sync_channel.py
@@ -71,7 +71,7 @@ class Channel(BaseChannel):
         buf = self.transport.read()
         buf = buf.replace(b"\r", b"")
 
-        self.logger.debug(f"read: {buf!r}")
+        self.logger.debug("read: %r", buf)
 
         if self.channel_log:
             self.channel_log.write(buf)
@@ -492,7 +492,8 @@ class Channel(BaseChannel):
         bytes_channel_input = channel_input.encode()
 
         self.logger.info(
-            f"sending channel input: {channel_input}; strip_prompt: {strip_prompt}; eager: {eager}"
+            "sending channel input: %s; strip_prompt: %s; eager: %s",
+            channel_input, strip_prompt, eager
         )
 
         with self._channel_lock():
@@ -547,8 +548,9 @@ class Channel(BaseChannel):
         ]
 
         self.logger.info(
-            f"sending channel input and read: {channel_input}; strip_prompt: {strip_prompt}; "
-            f"expected_outputs: {expected_outputs}; read_duration: {read_duration}"
+            "sending channel input and read: %s; strip_prompt: %s; "
+            "expected_outputs: %s; read_duration: %s",
+            channel_input, strip_prompt, expected_outputs, read_duration
         )
 
         with self._channel_lock():
@@ -658,9 +660,10 @@ class Channel(BaseChannel):
 
                 _channel_input = channel_input if not hidden_input else "REDACTED"
                 self.logger.info(
-                    f"sending interactive input: {_channel_input}; "
-                    f"expecting: {channel_response}; "
-                    f"hidden_input: {hidden_input}"
+                    "sending interactive input: %s; "
+                    "expecting: %s; "
+                    "hidden_input: %s",
+                    _channel_input, channel_response, hidden_input
                 )
 
                 self.write(channel_input=channel_input, redacted=bool(hidden_input))

--- a/scrapli/channel/sync_channel.py
+++ b/scrapli/channel/sync_channel.py
@@ -493,7 +493,9 @@ class Channel(BaseChannel):
 
         self.logger.info(
             "sending channel input: %s; strip_prompt: %s; eager: %s",
-            channel_input, strip_prompt, eager
+            channel_input,
+            strip_prompt,
+            eager,
         )
 
         with self._channel_lock():
@@ -550,7 +552,10 @@ class Channel(BaseChannel):
         self.logger.info(
             "sending channel input and read: %s; strip_prompt: %s; "
             "expected_outputs: %s; read_duration: %s",
-            channel_input, strip_prompt, expected_outputs, read_duration
+            channel_input,
+            strip_prompt,
+            expected_outputs,
+            read_duration,
         )
 
         with self._channel_lock():
@@ -660,10 +665,10 @@ class Channel(BaseChannel):
 
                 _channel_input = channel_input if not hidden_input else "REDACTED"
                 self.logger.info(
-                    "sending interactive input: %s; "
-                    "expecting: %s; "
-                    "hidden_input: %s",
-                    _channel_input, channel_response, hidden_input
+                    "sending interactive input: %s; " "expecting: %s; " "hidden_input: %s",
+                    _channel_input,
+                    channel_response,
+                    hidden_input,
                 )
 
                 self.write(channel_input=channel_input, redacted=bool(hidden_input))

--- a/scrapli/transport/base/base_transport.py
+++ b/scrapli/transport/base/base_transport.py
@@ -23,7 +23,6 @@ class BasePluginTransportArgs:
 
 
 class BaseTransport(ABC):
-
     def __init__(self, base_transport_args: BaseTransportArgs) -> None:
         """
         Scrapli's transport base class

--- a/tests/unit/channel/test_async_channel.py
+++ b/tests/unit/channel/test_async_channel.py
@@ -67,7 +67,7 @@ async def test_channel_read(fs_, caplog, monkeypatch, async_transport_no_abc):
     # assert the log output/level as expected; skip the first log message that will be about
     # channel_log being on
     log_record = caplog.records[1]
-    assert "read: b'read_data'" == log_record.msg
+    assert "read: b'read_data'" == log_record.message
     assert logging.DEBUG == log_record.levelno
 
     # assert channel log output as expected

--- a/tests/unit/channel/test_base_channel.py
+++ b/tests/unit/channel/test_base_channel.py
@@ -136,7 +136,7 @@ def test_channel_write(caplog, monkeypatch, base_channel):
     assert transport_write_called is True
 
     log_record = next(iter(caplog.records))
-    assert "write: 'blah'" == log_record.msg
+    assert "write: 'blah'" == log_record.message
     assert logging.DEBUG == log_record.levelno
 
 
@@ -155,7 +155,7 @@ def test_channel_write_redacted(caplog, monkeypatch, base_channel):
     assert transport_write_called is True
 
     log_record = next(iter(caplog.records))
-    assert "write: REDACTED" == log_record.msg
+    assert "write: REDACTED" == log_record.message
     assert logging.DEBUG == log_record.levelno
 
 

--- a/tests/unit/channel/test_sync_channel.py
+++ b/tests/unit/channel/test_sync_channel.py
@@ -59,7 +59,7 @@ def test_channel_read(fs_, caplog, monkeypatch, sync_transport_no_abc):
     # assert the log output/level as expected; skip the first log message that will be about
     # channel_log being on
     log_record = caplog.records[1]
-    assert "read: b'read_data'" == log_record.msg
+    assert "read: b'read_data'" == log_record.message
     assert logging.DEBUG == log_record.levelno
 
     # assert channel log output as expected

--- a/tests/unit/driver/base/test_base_base_driver.py
+++ b/tests/unit/driver/base/test_base_base_driver.py
@@ -392,7 +392,6 @@ def test_transport_factory_non_core(monkeypatch, test_data):
     ),
 )
 def test_resolve_ssh_config(fs_, real_ssh_config_file_path, base_driver, test_data):
-
     transport, input_data, expected_output, mount_real_file, fake_fs_destination = test_data
     if mount_real_file:
         fs_.add_real_file(source_path=real_ssh_config_file_path, target_path=fake_fs_destination)


### PR DESCRIPTION
# Description

`f-strings` are evaluated before passing them down to the logging functions (even if they are not used). By using boring (and IMO harder to read) `%s` or `%r` we can delay or elude that work depending on the logging settings.

With debug level logging disabled, this won't necessarily save a noticeable amount of run time on one individual run but will save CPU cycles none the less.

This also does not change all the instances of passing `f-strings` to logging functions. My goal was only to change the ones that would have the biggest impact (i.e. evaluating `f"read: {buf!r}"` every `read` even with debug logging disabled)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've run a handful of scripts with and without logging enabled and everything seems to be working the same. I've used `py-spy` to approximate that there is less work happening with debugging disabled.

# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
