### PR TITLE
Bypass

### DIFF
--- a/scrapli/transport/plugins/asynctelnet/transport.py
+++ b/scrapli/transport/plugins/asynctelnet/transport.py
@@ -119,7 +119,7 @@ class AsynctelnetTransport(AsyncTransport):
 
         if self._raw_buf.find(NULL) != -1:
             raise ScrapliConnectionNotOpened("server returned EOF, connection not opened")
-        
+
         index = self._raw_buf.find(IAC)
         if index == -1:
             self._cooked_buf = self._raw_buf
@@ -128,7 +128,7 @@ class AsynctelnetTransport(AsyncTransport):
 
         self._cooked_buf = self._raw_buf[:index]
         self._raw_buf = self._raw_buf[index:]
-        
+
         # control_buf is the buffer for control characters, we reset this after being "done" with
         # responding to a control sequence, so it always represents the "current" control sequence
         # we are working on responding to

--- a/scrapli/transport/plugins/asynctelnet/transport.py
+++ b/scrapli/transport/plugins/asynctelnet/transport.py
@@ -117,6 +117,18 @@ class AsynctelnetTransport(AsyncTransport):
         if not self.stdout:
             raise ScrapliConnectionNotOpened
 
+        if self._raw_buf.find(NULL) != -1:
+            raise ScrapliConnectionNotOpened("server returned EOF, connection not opened")
+        
+        index = self._raw_buf.find(IAC)
+        if index == -1:
+            self._cooked_buf = self._raw_buf
+            self._raw_buf = b""
+            return
+
+        self._cooked_buf = self._raw_buf[:index]
+        self._raw_buf = self._raw_buf[index:]
+        
         # control_buf is the buffer for control characters, we reset this after being "done" with
         # responding to a control sequence, so it always represents the "current" control sequence
         # we are working on responding to
@@ -124,9 +136,6 @@ class AsynctelnetTransport(AsyncTransport):
 
         while self._raw_buf:
             c, self._raw_buf = self._raw_buf[:1], self._raw_buf[1:]
-            if not c:
-                raise ScrapliConnectionNotOpened("server returned EOF, connection not opened")
-
             control_buf = self._handle_control_chars_response(control_buf=control_buf, c=c)
 
     async def open(self) -> None:
@@ -204,9 +213,6 @@ class AsynctelnetTransport(AsyncTransport):
     async def read(self) -> bytes:
         if not self.stdout:
             raise ScrapliConnectionNotOpened
-
-        if self._control_char_sent_counter < self._control_char_sent_limit:
-            self._handle_control_chars()
 
         while not self._cooked_buf and not self._eof:
             await self._read()

--- a/scrapli/transport/plugins/telnet/transport.py
+++ b/scrapli/transport/plugins/telnet/transport.py
@@ -150,7 +150,7 @@ class TelnetTransport(Transport):
 
         if self._raw_buf.find(NULL) != -1:
             raise ScrapliConnectionNotOpened("server returned EOF, connection not opened")
-        
+
         index = self._raw_buf.find(IAC)
         if index == -1:
             self._cooked_buf = self._raw_buf

--- a/tests/unit/driver/core/cisco_nxos/test_cisco_nxos_base_driver.py
+++ b/tests/unit/driver/core/cisco_nxos/test_cisco_nxos_base_driver.py
@@ -69,9 +69,9 @@ def test_create_configuration_session(sync_nxos_driver):
     sync_nxos_driver.privilege_levels["tacocat"].name = "tacocat"
     sync_nxos_driver.privilege_levels["tacocat"].previous_priv = "privilege_exec"
     sync_nxos_driver.privilege_levels["tacocat"].escalate = "configure session tacocat"
-    sync_nxos_driver.privilege_levels[
-        "tacocat"
-    ].pattern = r"^[a-z0-9.\-_@/:]{1,32}\(config\-s[a-z0-9.\-@/:]{0,32}\)#\s?$"
+    sync_nxos_driver.privilege_levels["tacocat"].pattern = (
+        r"^[a-z0-9.\-_@/:]{1,32}\(config\-s[a-z0-9.\-@/:]{0,32}\)#\s?$"
+    )
 
     with pytest.raises(ScrapliValueError):
         sync_nxos_driver._create_configuration_session(session_name="tacocat")

--- a/tests/unit/driver/core/cisco_nxos/test_cisco_nxos_base_driver.py
+++ b/tests/unit/driver/core/cisco_nxos/test_cisco_nxos_base_driver.py
@@ -69,9 +69,9 @@ def test_create_configuration_session(sync_nxos_driver):
     sync_nxos_driver.privilege_levels["tacocat"].name = "tacocat"
     sync_nxos_driver.privilege_levels["tacocat"].previous_priv = "privilege_exec"
     sync_nxos_driver.privilege_levels["tacocat"].escalate = "configure session tacocat"
-    sync_nxos_driver.privilege_levels["tacocat"].pattern = (
-        r"^[a-z0-9.\-_@/:]{1,32}\(config\-s[a-z0-9.\-@/:]{0,32}\)#\s?$"
-    )
+    sync_nxos_driver.privilege_levels[
+        "tacocat"
+    ].pattern = r"^[a-z0-9.\-_@/:]{1,32}\(config\-s[a-z0-9.\-@/:]{0,32}\)#\s?$"
 
     with pytest.raises(ScrapliValueError):
         sync_nxos_driver._create_configuration_session(session_name="tacocat")

--- a/tests/unit/transport/plugins/asynctelnet/test_asynctelnet_transport.py
+++ b/tests/unit/transport/plugins/asynctelnet/test_asynctelnet_transport.py
@@ -57,7 +57,7 @@ def test_handle_control_characters_response_exception(asynctelnet_transport):
         asynctelnet_transport._handle_control_chars_response(control_buf=b"", c=b"")
 
 
-async def test_handle_control_characters(monkeypatch, asynctelnet_transport):
+def test_handle_control_characters(monkeypatch, asynctelnet_transport):
     # lie like connection is open
     asynctelnet_transport.stdin = BytesIO()
     asynctelnet_transport.stdout = asyncio.StreamReader()
@@ -69,9 +69,23 @@ async def test_handle_control_characters(monkeypatch, asynctelnet_transport):
     assert asynctelnet_transport._cooked_buf == bytes([253])
 
 
-async def test_handle_control_characters_exception(asynctelnet_transport):
+def test_handle_control_characters_actually_finds_control_command(
+    monkeypatch, asynctelnet_transport
+):
+    # lie like connection is open
+    asynctelnet_transport.stdin = BytesIO()
+    asynctelnet_transport.stdout = asyncio.StreamReader()
+    asynctelnet_transport._base_transport_args.timeout_socket = 0.4
+
+    asynctelnet_transport._raw_buf = bytes([33, 255, 251, 34, 35])
+    asynctelnet_transport._handle_control_chars()
+
+    assert asynctelnet_transport._cooked_buf == bytes([33, 35])
+
+
+def test_handle_control_characters_exception(asynctelnet_transport):
     with pytest.raises(ScrapliConnectionNotOpened):
-        await asynctelnet_transport._handle_control_chars()
+        asynctelnet_transport._handle_control_chars()
 
 
 def test_close(asynctelnet_transport):

--- a/tests/unit/transport/plugins/telnet/test_telnet_transport.py
+++ b/tests/unit/transport/plugins/telnet/test_telnet_transport.py
@@ -45,7 +45,8 @@ def test_handle_control_characters_response_third_char(telnet_transport, test_da
     control_buf_input, expected_output = test_data
 
     # lie to transport so socket is not None and give sock a thing to write to
-    class Dummy: ...
+    class Dummy:
+        ...
 
     class DummySock:
         def __init__(self):
@@ -75,7 +76,8 @@ def test_handle_control_characters_response_exception(telnet_transport):
 
 def test_handle_control_characters(monkeypatch, telnet_transport):
     # lie like connection is open
-    class Dummy: ...
+    class Dummy:
+        ...
 
     class DummySock:
         def __init__(self):
@@ -84,7 +86,8 @@ def test_handle_control_characters(monkeypatch, telnet_transport):
         def send(self, channel_input):
             self.buf.write(channel_input)
 
-        def settimeout(self, t): ...
+        def settimeout(self, t):
+            ...
 
     telnet_transport.socket = Dummy()
     telnet_transport.socket.sock = DummySock()
@@ -95,6 +98,30 @@ def test_handle_control_characters(monkeypatch, telnet_transport):
     assert telnet_transport._cooked_buf == bytes([253])
 
 
+def test_handle_control_characters_actually_finds_control_command(monkeypatch, telnet_transport):
+    # lie like connection is open
+    class Dummy:
+        ...
+
+    class DummySock:
+        def __init__(self):
+            self.buf = BytesIO()
+
+        def send(self, channel_input):
+            self.buf.write(channel_input)
+
+        def settimeout(self, t):
+            ...
+
+    telnet_transport.socket = Dummy()
+    telnet_transport.socket.sock = DummySock()
+
+    telnet_transport._raw_buf = bytes([33, 255, 251, 34, 35])
+    telnet_transport._handle_control_chars()
+
+    assert telnet_transport._cooked_buf == bytes([33, 35])
+
+
 def test_handle_control_characters_exception(telnet_transport):
     with pytest.raises(ScrapliConnectionNotOpened):
         telnet_transport._handle_control_chars()
@@ -103,7 +130,8 @@ def test_handle_control_characters_exception(telnet_transport):
 def test_close(telnet_transport):
     # lie like connection is open
     class Dummy:
-        def close(self): ...
+        def close(self):
+            ...
 
     telnet_transport.socket = Dummy()
 
@@ -129,7 +157,8 @@ def test_isalive(telnet_transport):
 
 async def test_read(telnet_transport):
     # lie like connection is open
-    class Dummy: ...
+    class Dummy:
+        ...
 
     class DummySock:
         def __init__(self):
@@ -138,7 +167,8 @@ async def test_read(telnet_transport):
         def send(self, channel_input):
             self.buf.write(channel_input)
 
-        def settimeout(self, t): ...
+        def settimeout(self, t):
+            ...
 
         def recv(self, n):
             self.buf.seek(0)
@@ -154,7 +184,8 @@ async def test_read(telnet_transport):
 def test_read_timeout(telnet_transport):
     # lie like connection is open
     class Dummy:
-        def close(self): ...
+        def close(self):
+            ...
 
     class DummySock:
         def __init__(self):
@@ -167,7 +198,8 @@ def test_read_timeout(telnet_transport):
             time.sleep(1)
             return self.buf.read()
 
-        def settimeout(self, t): ...
+        def settimeout(self, t):
+            ...
 
     telnet_transport.socket = Dummy()
     telnet_transport.socket.sock = DummySock()
@@ -180,7 +212,8 @@ def test_read_timeout(telnet_transport):
 def test_write(telnet_transport):
     # lie like connection is open
     class Dummy:
-        def close(self): ...
+        def close(self):
+            ...
 
     class DummySock:
         def __init__(self):
@@ -193,7 +226,8 @@ def test_write(telnet_transport):
             time.sleep(1)
             return self.buf.read()
 
-        def settimeout(self, t): ...
+        def settimeout(self, t):
+            ...
 
     telnet_transport.socket = Dummy()
     telnet_transport.socket.sock = DummySock()

--- a/tests/unit/transport/plugins/telnet/test_telnet_transport.py
+++ b/tests/unit/transport/plugins/telnet/test_telnet_transport.py
@@ -45,8 +45,7 @@ def test_handle_control_characters_response_third_char(telnet_transport, test_da
     control_buf_input, expected_output = test_data
 
     # lie to transport so socket is not None and give sock a thing to write to
-    class Dummy:
-        ...
+    class Dummy: ...
 
     class DummySock:
         def __init__(self):
@@ -76,8 +75,7 @@ def test_handle_control_characters_response_exception(telnet_transport):
 
 def test_handle_control_characters(monkeypatch, telnet_transport):
     # lie like connection is open
-    class Dummy:
-        ...
+    class Dummy: ...
 
     class DummySock:
         def __init__(self):
@@ -86,8 +84,7 @@ def test_handle_control_characters(monkeypatch, telnet_transport):
         def send(self, channel_input):
             self.buf.write(channel_input)
 
-        def settimeout(self, t):
-            ...
+        def settimeout(self, t): ...
 
     telnet_transport.socket = Dummy()
     telnet_transport.socket.sock = DummySock()
@@ -100,8 +97,7 @@ def test_handle_control_characters(monkeypatch, telnet_transport):
 
 def test_handle_control_characters_actually_finds_control_command(monkeypatch, telnet_transport):
     # lie like connection is open
-    class Dummy:
-        ...
+    class Dummy: ...
 
     class DummySock:
         def __init__(self):
@@ -110,8 +106,7 @@ def test_handle_control_characters_actually_finds_control_command(monkeypatch, t
         def send(self, channel_input):
             self.buf.write(channel_input)
 
-        def settimeout(self, t):
-            ...
+        def settimeout(self, t): ...
 
     telnet_transport.socket = Dummy()
     telnet_transport.socket.sock = DummySock()
@@ -130,8 +125,7 @@ def test_handle_control_characters_exception(telnet_transport):
 def test_close(telnet_transport):
     # lie like connection is open
     class Dummy:
-        def close(self):
-            ...
+        def close(self): ...
 
     telnet_transport.socket = Dummy()
 
@@ -157,8 +151,7 @@ def test_isalive(telnet_transport):
 
 async def test_read(telnet_transport):
     # lie like connection is open
-    class Dummy:
-        ...
+    class Dummy: ...
 
     class DummySock:
         def __init__(self):
@@ -167,8 +160,7 @@ async def test_read(telnet_transport):
         def send(self, channel_input):
             self.buf.write(channel_input)
 
-        def settimeout(self, t):
-            ...
+        def settimeout(self, t): ...
 
         def recv(self, n):
             self.buf.seek(0)
@@ -184,8 +176,7 @@ async def test_read(telnet_transport):
 def test_read_timeout(telnet_transport):
     # lie like connection is open
     class Dummy:
-        def close(self):
-            ...
+        def close(self): ...
 
     class DummySock:
         def __init__(self):
@@ -198,8 +189,7 @@ def test_read_timeout(telnet_transport):
             time.sleep(1)
             return self.buf.read()
 
-        def settimeout(self, t):
-            ...
+        def settimeout(self, t): ...
 
     telnet_transport.socket = Dummy()
     telnet_transport.socket.sock = DummySock()
@@ -212,8 +202,7 @@ def test_read_timeout(telnet_transport):
 def test_write(telnet_transport):
     # lie like connection is open
     class Dummy:
-        def close(self):
-            ...
+        def close(self): ...
 
     class DummySock:
         def __init__(self):
@@ -226,8 +215,7 @@ def test_write(telnet_transport):
             time.sleep(1)
             return self.buf.read()
 
-        def settimeout(self, t):
-            ...
+        def settimeout(self, t): ...
 
     telnet_transport.socket = Dummy()
     telnet_transport.socket.sock = DummySock()


### PR DESCRIPTION
# Description

Bypass buffers with no control chars.

If buffers do not have any control characters then they can be processed in one bulk move rather than byte-by-byte.

This is a lot more efficient with devices that never hit `_control_char_sent_limit`.

Also the first call to `_handle_control_chars` in `read` is unnecessary since `_handle_control_chars` consumes the entire `_raw_buf`. (meaning it is always starts empty when you call `read`)

Notable things not addressed:
- Most instances of `b""` (a `bytes` structure) should be
  `bytearray()` since `bytes` are not mutable.
- if a control sequence is not contained in a single read it will
  not get processed.
- The following code would be a little bit more efficient as a
  `memoryview` since it would skip copying the contents  of
  `_raw_buf` every iteration.
  `c, self._raw_buf = self._raw_buf[:1], self._raw_buf[1:]`

I left those out to minimize this patch, but can circle back around and fix them later.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have tried the changes out locally with some of the scripts we have around.

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
