### PR TITLE
Update ntc-templates requirement from <5.0.0 to <7.0.0

### DIFF
--- a/requirements-textfsm.txt
+++ b/requirements-textfsm.txt
@@ -1,2 +1,2 @@
-ntc-templates>=1.1.0,<5.0.0
+ntc-templates>=1.1.0,<7.0.0
 textfsm>=1.1.0,<2.0.0


### PR DESCRIPTION
# Description

Changed file [requirements-textfsm.txt](https://github.com/carlmontanari/scrapli/blob/main/requirements-textfsm.txt) to allow new ntc_templates version (6.0.0). PR to fix issue #346  

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've forked the repository and enabled github actions. All github actions ran without complaints. Also my scripts that use scrapli+ntc-templates work without problems.

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
