### PR TITLE
Allow exceptions in the textfsm parsing process to be handled by caller

### DIFF
--- a/docs/user_guide/basic_usage.md
+++ b/docs/user_guide/basic_usage.md
@@ -268,7 +268,8 @@ scrapli supports parsing output with TextFSM and ntc-templates. This of course r
  set for you (based on the driver device type). If you wish to parse the output of your send commands, you can use the
   `textfsm_parse_output` method of the response object. This method will attempt to find the template for you
    -- based on the textfsm-platform and the channel-input (the command sent). If textfsm parsing succeeds, the
-    structured result is returned. If textfsm parsing fails, an empty list is returned.
+    structured result is returned. If textfsm parsing fails, an empty list is returned. The `textfsm_parse_output` method 
+    also accepts the `raise_err` field to allow parsing exceptions to be handled by the caller.
 
 ```python
 from scrapli.driver.core import IOSXEDriver

--- a/docs/user_guide/basic_usage.md
+++ b/docs/user_guide/basic_usage.md
@@ -269,7 +269,7 @@ scrapli supports parsing output with TextFSM and ntc-templates. This of course r
   `textfsm_parse_output` method of the response object. This method will attempt to find the template for you
    -- based on the textfsm-platform and the channel-input (the command sent). If textfsm parsing succeeds, the
     structured result is returned. If textfsm parsing fails, an empty list is returned. The `textfsm_parse_output` method 
-    also accepts the `raise_err` field to allow parsing exceptions to be handled by the caller.
+    also accepts an optional `raise_err` argument to allow parsing exceptions to be handled by the caller.
 
 ```python
 from scrapli.driver.core import IOSXEDriver

--- a/scrapli/helper.py
+++ b/scrapli/helper.py
@@ -113,7 +113,8 @@ def textfsm_parse(
         output: structured data
 
     Raises:
-        textfsm.parser.TextFSMError: If raise_err is set and a textfsm parsing error occours
+        ScrapliException: If raise_err is set and a textfsm parsing error occurs, raises from the
+            originating textfsm.parser.TextFSMError exception.
 
     """
     import textfsm  # pylint: disable=C0415

--- a/scrapli/helper.py
+++ b/scrapli/helper.py
@@ -97,7 +97,7 @@ def _textfsm_to_dict(
 
 
 def textfsm_parse(
-    template: Union[str, TextIOWrapper], output: str, to_dict: bool = True
+    template: Union[str, TextIOWrapper], output: str, to_dict: bool = True, raise_err: bool = False
 ) -> Union[List[Any], Dict[str, Any]]:
     """
     Parse output with TextFSM and ntc-templates, try to return structured output
@@ -107,6 +107,7 @@ def textfsm_parse(
         output: unstructured output from device to parse
         to_dict: convert textfsm output from list of lists to list of dicts -- basically create dict
             from header and row data so it is easier to read/parse the output
+        raise_err: exceptions in the textfsm parser will raised for the caller to handle
 
     Returns:
         output: structured data
@@ -136,8 +137,10 @@ def textfsm_parse(
                 structured_output=structured_output, header=re_table.header
             )
         return structured_output
-    except textfsm.parser.TextFSMError:
+    except textfsm.parser.TextFSMError as e:
         logger.warning("failed to parse data with textfsm")
+        if raise_err:
+            raise e
     return []
 
 

--- a/scrapli/helper.py
+++ b/scrapli/helper.py
@@ -113,7 +113,7 @@ def textfsm_parse(
         output: structured data
 
     Raises:
-        N/A
+        textfsm.parser.TextFSMError: If raise_err is set and a textfsm parsing error occours
 
     """
     import textfsm  # pylint: disable=C0415
@@ -137,10 +137,10 @@ def textfsm_parse(
                 structured_output=structured_output, header=re_table.header
             )
         return structured_output
-    except textfsm.parser.TextFSMError as e:
+    except textfsm.parser.TextFSMError:
         logger.warning("failed to parse data with textfsm")
         if raise_err:
-            raise e
+            raise
     return []
 
 

--- a/scrapli/helper.py
+++ b/scrapli/helper.py
@@ -10,7 +10,7 @@ from shutil import get_terminal_size
 from typing import Any, Dict, List, Optional, TextIO, Tuple, Union
 from warnings import warn
 
-from scrapli.exceptions import ScrapliValueError
+from scrapli.exceptions import ScrapliException, ScrapliValueError
 from scrapli.logging import logger
 from scrapli.settings import Settings
 
@@ -137,10 +137,10 @@ def textfsm_parse(
                 structured_output=structured_output, header=re_table.header
             )
         return structured_output
-    except textfsm.parser.TextFSMError:
+    except textfsm.parser.TextFSMError as exc:
         logger.warning("failed to parse data with textfsm")
         if raise_err:
-            raise
+            raise ScrapliException(exc) from exc
     return []
 
 

--- a/scrapli/response.py
+++ b/scrapli/response.py
@@ -142,7 +142,10 @@ class Response:
             self.failed = False
 
     def textfsm_parse_output(
-        self, template: Union[str, TextIO, None] = None, to_dict: bool = True
+        self,
+        template: Union[str, TextIO, None] = None,
+        to_dict: bool = True,
+        raise_err: bool = False,
     ) -> Union[Dict[str, Any], List[Any]]:
         """
         Parse results with textfsm, always return structured data
@@ -153,7 +156,7 @@ class Response:
             template: string path to textfsm template or opened textfsm template file
             to_dict: convert textfsm output from list of lists to list of dicts -- basically create
                 dict from header and row data so it is easier to read/parse the output
-
+            raise_err: exceptions in the textfsm parser will raised for the caller to handle
         Returns:
             structured_result: empty list or parsed data from textfsm
 
@@ -170,7 +173,12 @@ class Response:
             return []
 
         template = cast(Union[str, TextIOWrapper], template)
-        return textfsm_parse(template=template, output=self.result, to_dict=to_dict) or []
+        return (
+            textfsm_parse(
+                template=template, output=self.result, to_dict=to_dict, raise_err=raise_err
+            )
+            or []
+        )
 
     def genie_parse_output(self) -> Union[Dict[str, Any], List[Any]]:
         """

--- a/scrapli/response.py
+++ b/scrapli/response.py
@@ -157,6 +157,7 @@ class Response:
             to_dict: convert textfsm output from list of lists to list of dicts -- basically create
                 dict from header and row data so it is easier to read/parse the output
             raise_err: exceptions in the textfsm parser will raised for the caller to handle
+
         Returns:
             structured_result: empty list or parsed data from textfsm
 

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -142,6 +142,13 @@ def test_textfsm_parse_failed_to_parse():
     assert result == []
 
 
+def test_textfsm_parse_failed_to_parse_with_raise():
+    template = _textfsm_get_template("cisco_ios", "show ip arp")
+    with pytest.raises(Exception):
+        result = textfsm_parse(template, "not really arp data", raise_err=True)
+        assert result == []
+
+
 @pytest.mark.skipif(
     sys.version_info.minor > 10, reason="genie not currently available for python 3.11"
 )

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -155,6 +155,14 @@ def test_response_parse_textfsm_fail():
     assert response.textfsm_parse_output() == []
 
 
+def test_response_parse_textfsm_fail_with_raise():
+    response = Response("localhost", channel_input="show ip arp", textfsm_platform="cisco_ios")
+    response_bytes = b"not ip arp output"
+    response.record_response(response_bytes)
+    with pytest.raises(Exception):
+        assert response.textfsm_parse_output(raise_err=True) == []
+
+
 def test_response_parse_textfsm_no_template():
     response = Response("localhost", channel_input="show ip arp", textfsm_platform="potato")
     response_bytes = b""


### PR DESCRIPTION

# Description

When using the convenience function `response.textfsm_parse_output()` to parse output from commands, there is currently no way to tell the difference between a parsing exception and an "empty" command output. For example the output from `show vrf` on a router with no vrfs will be empty and will return `[]`, the same empty array will return if the vrf command fails to parse. There is currently a log message that will tell you something is wrong, however this cannot effect the control flow of the program allowing us to handle this error.

This change adds an optional `raise_err` field to `textfsm_parse_output()` to bubble the parsing exception up the stack. As its an optional field, existing code bases will continue to function as before.
 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
Tests have been run

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
