### PR TITLE
fix read_callback user provided input case (in)sensitivity

### DIFF
--- a/scrapli/driver/generic/base_driver.py
+++ b/scrapli/driver/generic/base_driver.py
@@ -123,6 +123,8 @@ class ReadCallback:
         """
         if self.contains and not self._contains_bytes:
             self._contains_bytes = self.contains.encode()
+            if self.case_insensitive:
+                self._contains_bytes = self._contains_bytes.lower()
 
         return self._contains_bytes
 
@@ -143,6 +145,8 @@ class ReadCallback:
         """
         if self.not_contains and not self._not_contains_bytes:
             self._not_contains_bytes = self.not_contains.encode()
+            if self.case_insensitive:
+                self._not_contains_bytes = self._not_contains_bytes.lower()
 
         return self._not_contains_bytes
 

--- a/tests/unit/driver/generic/test_generic_async_driver.py
+++ b/tests/unit/driver/generic/test_generic_async_driver.py
@@ -143,6 +143,13 @@ async def test_readcallback_basic(monkeypatch, async_generic_driver):
             only_once=True,
         ),
         ReadCallback(
+            contains="RTR1#",
+            callback=callback_one,
+            name="call1.5",
+            case_insensitive=True,
+            only_once=True,
+        ),
+        ReadCallback(
             contains_re=r"^rtr1#",
             callback=callback_two,
             complete=True,
@@ -151,5 +158,5 @@ async def test_readcallback_basic(monkeypatch, async_generic_driver):
 
     await async_generic_driver.read_callback(callbacks=callbacks, initial_input="nada")
 
-    assert callback_one_counter == 1
+    assert callback_one_counter == 2
     assert callback_two_counter == 1

--- a/tests/unit/driver/generic/test_generic_sync_driver.py
+++ b/tests/unit/driver/generic/test_generic_sync_driver.py
@@ -132,6 +132,13 @@ def test_readcallback_basic(monkeypatch, sync_generic_driver):
             only_once=True,
         ),
         ReadCallback(
+            contains="RTR1#",
+            callback=callback_one,
+            name="call1.5",
+            case_insensitive=True,
+            only_once=True,
+        ),
+        ReadCallback(
             contains_re=r"^rtr1#",
             callback=callback_two,
             complete=True,
@@ -140,5 +147,5 @@ def test_readcallback_basic(monkeypatch, sync_generic_driver):
 
     sync_generic_driver.read_callback(callbacks=callbacks, initial_input="nada")
 
-    assert callback_one_counter == 1
+    assert callback_one_counter == 2
     assert callback_two_counter == 1


### PR DESCRIPTION
# Description

This PR is about to handle the situation when user provides input for ``contains`` or ``not_contains`` with capital letters while ``case_insensitive`` attribute only lowers device input's case. Previously, input is not matched though the difference is only letter case. This fix basically lowers user input strings if ``case_insensitive`` is True and string ``in`` operator will work as intended.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

pytest case added in line with the spirit of the project owner.


# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [X] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
