### PR TITLE
Deleted EOF control in telnet sync/async control chars

### DIFF
--- a/scrapli/transport/plugins/asynctelnet/transport.py
+++ b/scrapli/transport/plugins/asynctelnet/transport.py
@@ -110,8 +110,6 @@ class AsynctelnetTransport(AsyncTransport):
 
         Raises:
             ScrapliConnectionNotOpened: if connection is not opened for some reason
-            ScrapliConnectionNotOpened: if we read an empty byte string from the reader -- this
-                indicates the server sent an EOF -- see #142
 
         """
         if not self.stdout:

--- a/scrapli/transport/plugins/asynctelnet/transport.py
+++ b/scrapli/transport/plugins/asynctelnet/transport.py
@@ -117,9 +117,6 @@ class AsynctelnetTransport(AsyncTransport):
         if not self.stdout:
             raise ScrapliConnectionNotOpened
 
-        if self._raw_buf.find(NULL) != -1:
-            raise ScrapliConnectionNotOpened("server returned EOF, connection not opened")
-
         index = self._raw_buf.find(IAC)
         if index == -1:
             self._cooked_buf = self._raw_buf

--- a/scrapli/transport/plugins/telnet/transport.py
+++ b/scrapli/transport/plugins/telnet/transport.py
@@ -141,8 +141,6 @@ class TelnetTransport(Transport):
 
         Raises:
             ScrapliConnectionNotOpened: if connection is not opened for some reason
-            ScrapliConnectionNotOpened: if we read an empty byte string from the reader -- this
-                indicates the server sent an EOF -- see #142
 
         """
         if not self.socket:

--- a/scrapli/transport/plugins/telnet/transport.py
+++ b/scrapli/transport/plugins/telnet/transport.py
@@ -148,9 +148,6 @@ class TelnetTransport(Transport):
         if not self.socket:
             raise ScrapliConnectionNotOpened
 
-        if self._raw_buf.find(NULL) != -1:
-            raise ScrapliConnectionNotOpened("server returned EOF, connection not opened")
-
         index = self._raw_buf.find(IAC)
         if index == -1:
             self._cooked_buf = self._raw_buf


### PR DESCRIPTION
# Description
PR related to issue #351.

The EOF sequence control has been added to telnet transport in PR #143 (Dmitriy's issue #142 ), however, after [Matt's contribution](https://github.com/carlmontanari/scrapli/pull/344#discussion_r1690564573), the EOF control can be removed from the `_handle_control_chars` method.

Also, connecting devices like Cisco PIX and some old ASA, that control raised the `scrapli.exceptions.ScrapliConnectionNotOpened: server returned EOF, connection not opened` exception. And it shouldn't.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested my update on a dozen devices, some of which inserted the EOF sequence in the middle of the stream, some at the end of the stream, and some did not. In all cases it worked well.


# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] New and existing unit tests pass locally with my changes
