### PR TITLE
add arista failed pattern

### DIFF
--- a/scrapli/driver/core/arista_eos/base_driver.py
+++ b/scrapli/driver/core/arista_eos/base_driver.py
@@ -51,6 +51,7 @@ FAILED_WHEN_CONTAINS = [
     "% Invalid input",
     "% Cannot commit",
     "% Unavailable command",
+    "% Duplicate sequence number",
 ]
 
 


### PR DESCRIPTION
Hi, 

In case of duplicated seq of prefix-list, arista writes `% Duplicate sequence number` which is not element of `FAILED_WHEN_CONTAINS` list for arista driver. This PR adds missed error message.

```
switch(config)#ip prefix-list pl_TEST seq 10 permit 192.168.0.0/24
switch(config)#do sh ip prefix-list pl_TEST
ip prefix-list pl_TEST seq 10 permit 192.168.0.0/24

switch(config)#ip prefix-list pl_TEST seq 10 permit 10.0.0.0/24
% Duplicate sequence number

switch(config)#do sh ip prefix-list pl_TEST
ip prefix-list pl_TEST seq 10 permit 192.168.0.0/24
switch(config)#
```
