### PR TITLE
add plus sign to prompt

### DIFF
--- a/scrapli/driver/core/arista_eos/base_driver.py
+++ b/scrapli/driver/core/arista_eos/base_driver.py
@@ -32,7 +32,7 @@ PRIVS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^[\w.\-@()/: ]{1,63}\(config[\w.\-@/:]{0,63}\)#\s?$",
+            pattern=r"^[\w.\-@()/: ]{1,63}\(config[\w.\-@/:+]{0,63}\)#\s?$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="end",
@@ -80,7 +80,7 @@ class EOSDriverBase:
             raise ScrapliValueError(msg)
         sess_prompt = re.escape(session_name[:6])
         pattern = (
-            rf"^[a-z0-9.\-@()/: ]{{1,63}}\(config\-s\-{sess_prompt}[a-z0-9_.\-@/:]{{0,64}}\)#\s?$"
+            rf"^[a-z0-9.\-@()/: ]{{1,63}}\(config\-s\-{sess_prompt}[a-z0-9_.\-@/:+]{{0,64}}\)#\s?$"
         )
         name = session_name
         config_session = PrivilegeLevel(

--- a/tests/unit/driver/core/arista_eos/test_arista_eos_base_driver.py
+++ b/tests/unit/driver/core/arista_eos/test_arista_eos_base_driver.py
@@ -20,6 +20,14 @@ from scrapli.exceptions import ScrapliPrivilegeError, ScrapliValueError
         ("configuration", "localhost(some thing)(config)#"),
         ("configuration", "localhost(some thing)(config-s-tacocat)#"),
         ("configuration", "eos_switch(config-s-scrapl-qos-profile-CORE-EGRESS-QUEUING-txq-5)#"),
+        (
+            "configuration",
+            "eos_switch(config-sg-tacacs+-my_group)#",
+        ),  # conf t / aaa group server tacacs+ my_group
+        (
+            "configuration",
+            "eos_switch(config-s-sc-sg-tacacs+-my_group)#",
+        ),  # conf s / aaa group server tacacs+ my_group
     ],
     ids=[
         "exec",
@@ -33,6 +41,8 @@ from scrapli.exceptions import ScrapliPrivilegeError, ScrapliValueError
         "config_with_space",
         "config_session",
         "config_session_very_long_qos_profile",
+        "config_terminal_tacacs_plus",
+        "config_session_tacacs_plus",
     ],
 )
 def test_prompt_patterns(priv_pattern, sync_eos_driver):


### PR DESCRIPTION
While configuring tacacs+ server group on arista, switch prompt has `+` sign, which is not matches existed prompt pattern.

```
switch(config)#aaa group server tacacs+ my_group
switch(config-sg-tacacs+-my_group)#
```

This PR adds `+` to pattern of "configuration" level (conf terminal and conf session modes)