### PR TITLE
Adding generic driver to core platforms

### DIFF
--- a/scrapli/factory.py
+++ b/scrapli/factory.py
@@ -229,6 +229,7 @@ class Scrapli(NetworkDriver):
         "cisco_iosxr": IOSXRDriver,
         "cisco_nxos": NXOSDriver,
         "juniper_junos": JunosDriver,
+        "generic": GenericDriver,
     }
     DRIVER_MAP = {"network": NetworkDriver, "generic": GenericDriver}
 

--- a/scrapli/factory.py
+++ b/scrapli/factory.py
@@ -308,7 +308,7 @@ class Scrapli(NetworkDriver):
         Parent get driver method for sync Scrapli
 
         Args:
-            platform: name of target platform; i.e. `cisco_iosxe`, `arista_eos`, etc.
+            platform: name of target platform; i.e. `cisco_iosxe`, `arista_eos`, `generic`, etc.
             variant: name of the target platform variant
 
         Returns:


### PR DESCRIPTION
# Description

Wondering if this was just an oversight or if this was omitted intentionally, but we're trying to solve for the case when we want to use the generic driver via the factory, so I don't have to explicitly call its constructor.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested by calling the `Scrapli` factory with platform set to  `generic`.


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
