### PR TITLE
Add more error messages to Junos CLI parser

### DIFF
--- a/scrapli/driver/core/juniper_junos/base_driver.py
+++ b/scrapli/driver/core/juniper_junos/base_driver.py
@@ -77,4 +77,6 @@ FAILED_WHEN_CONTAINS = [
     "No valid completions",
     "unknown command",
     "syntax error",
+    "missing mandatory argument",
+    "invalid numeric value",
 ]


### PR DESCRIPTION
# Description

While working with [Juniper QFX3000-M QFabric](https://www.juniper.net/documentation/product/us/en/qfx3000-m/) I've discovered that it has error messages that aren't caught by scrapli.

I've added them to `FAILED_WHEN_CONTAINS` in base_driver.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests aren't failing, but I don't where this is even tested.

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
