### PR TITLE
Update privilege level patterns to allow trailing spaces in cisco_iosxe

### DIFF
--- a/scrapli/driver/core/cisco_iosxe/base_driver.py
+++ b/scrapli/driver/core/cisco_iosxe/base_driver.py
@@ -5,7 +5,7 @@ from scrapli.driver.network.base_driver import PrivilegeLevel
 PRIVS = {
     "exec": (
         PrivilegeLevel(
-            pattern=r"^[\w.\-@/:]{1,63}>$",
+            pattern=r"^[\w.\-@/:]{1,63}>\s*$",
             name="exec",
             previous_priv="",
             deescalate="",
@@ -16,7 +16,7 @@ PRIVS = {
     ),
     "privilege_exec": (
         PrivilegeLevel(
-            pattern=r"^[\w.\-@/:]{1,63}#$",
+            pattern=r"^[\w.\-@/:]{1,63}#\s*$",
             name="privilege_exec",
             previous_priv="exec",
             deescalate="disable",
@@ -27,7 +27,7 @@ PRIVS = {
     ),
     "configuration": (
         PrivilegeLevel(
-            pattern=r"^[\w.\-@/:]{1,63}\([\w.\-@/:+]{0,32}\)#$",
+            pattern=r"^[\w.\-@/:]{1,63}\([\w.\-@/:+]{0,32}\)#\s*$",
             name="configuration",
             previous_priv="privilege_exec",
             deescalate="end",
@@ -39,7 +39,7 @@ PRIVS = {
     ),
     "tclsh": (
         PrivilegeLevel(
-            pattern=r"^([\w.\-@/+>:]+\(tcl\)[>#]|\+>)$",
+            pattern=r"^([\w.\-@/+>:]+\(tcl\)[>#]|\+>)\s*$",
             name="tclsh",
             previous_priv="privilege_exec",
             deescalate="tclquit",


### PR DESCRIPTION
# Description

See #380 

I'd be happy to update the cisco_iosxr if we think it should be updated


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See test procedure for identifying this possible issue. I can add additional unit tests if you want.

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
