### PR TITLE
feat: add in-memory SSH known hosts and private key support

### DIFF
--- a/scrapli/auth.py
+++ b/scrapli/auth.py
@@ -75,6 +75,7 @@ class Options:
 
     username: str | None = None
     password: str | None = None
+    private_key: str | None = None
     private_key_path: str | None = None
     private_key_passphrase: str | None = None
     lookups: list[LookupKeyValue] | None = None
@@ -86,6 +87,7 @@ class Options:
 
     _username: c_char_p | None = field(init=False, default=None, repr=False)
     _password: c_char_p | None = field(init=False, default=None, repr=False)
+    _private_key: c_char_p | None = field(init=False, default=None, repr=False)
     _private_key_path: c_char_p | None = field(init=False, default=None, repr=False)
     _private_key_passphrase: c_char_p | None = field(init=False, default=None, repr=False)
     _username_pattern: c_char_p | None = field(init=False, default=None, repr=False)
@@ -124,6 +126,12 @@ class Options:
 
             options.contents.auth.password = self._password
             options.contents.auth.password_len = c_size_t(len(self.password))
+
+        if self.private_key is not None:
+            self._private_key = to_c_string(self.private_key)
+
+            options.contents.auth.private_key = self._private_key
+            options.contents.auth.private_key_len = c_size_t(len(self.private_key))
 
         if self.private_key_path is not None:
             self._private_key_path = to_c_string(self.private_key_path)

--- a/scrapli/ffi_options.py
+++ b/scrapli/ffi_options.py
@@ -140,6 +140,8 @@ class Auth(Structure):
         ("username_len", c_size_t),
         ("password", c_char_p),
         ("password_len", c_size_t),
+        ("private_key", c_char_p),
+        ("private_key_len", c_size_t),
         ("private_key_path", c_char_p),
         ("private_key_path_len", c_size_t),
         ("private_key_passphrase", c_char_p),
@@ -180,6 +182,8 @@ class TransportBin(Structure):
         ("override_open_args_len", c_size_t),
         ("ssh_config_path", c_char_p),
         ("ssh_config_path_len", c_size_t),
+        ("known_hosts", c_char_p),
+        ("known_hosts_len", c_size_t),
         ("known_hosts_path", c_char_p),
         ("known_hosts_path_len", c_size_t),
         ("enable_strict_key", BoolPointer),
@@ -204,6 +208,8 @@ class TransportSSH2(Structure):
     """
 
     _fields_: ClassVar[list[tuple[str, Any]]] = [
+        ("known_hosts", c_char_p),
+        ("known_hosts_len", c_size_t),
         ("known_hosts_path", c_char_p),
         ("known_hosts_path_len", c_size_t),
         ("libssh2trace", BoolPointer),

--- a/scrapli/transport.py
+++ b/scrapli/transport.py
@@ -122,6 +122,7 @@ class BinOptions(Options):
     extra_open_args: list[str] | None = None
     override_open_args: list[str] | None = None
     ssh_config_path: str | None = None
+    known_hosts: str | None = None
     known_hosts_path: str | None = None
     enable_strict_key: bool | None = None
     term_height: int | None = None
@@ -131,6 +132,7 @@ class BinOptions(Options):
     _extra_open_args: c_char_p | None = field(init=False, default=None, repr=False)
     _override_open_args: c_char_p | None = field(init=False, default=None, repr=False)
     _ssh_config_path: c_char_p | None = field(init=False, default=None, repr=False)
+    _known_hosts: c_char_p | None = field(init=False, default=None, repr=False)
     _known_hosts_path: c_char_p | None = field(init=False, default=None, repr=False)
 
     def apply(self, *, options: DriverOptionsPointer) -> None:
@@ -174,6 +176,12 @@ class BinOptions(Options):
 
             options.contents.transport.bin.ssh_config_path = self._ssh_config_path
             options.contents.transport.bin.ssh_config_path_len = c_size_t(len(self.ssh_config_path))
+
+        if self.known_hosts is not None:
+            self._known_hosts = to_c_string(self.known_hosts)
+
+            options.contents.transport.bin.known_hosts = self._known_hosts
+            options.contents.transport.bin.known_hosts_len = c_size_t(len(self.known_hosts))
 
         if self.known_hosts_path is not None:
             self._known_hosts_path = to_c_string(self.known_hosts_path)
@@ -219,6 +227,7 @@ class Ssh2Options(Options):
 
     """
 
+    known_hosts: str | None = None
     known_hosts_path: str | None = None
     libssh2_trace: bool | None = None
 
@@ -230,6 +239,7 @@ class Ssh2Options(Options):
     proxy_jump_private_key_passphrase: str | None = None
     proxy_jump_libssh2_trace: bool | None = None
 
+    _known_hosts: c_char_p | None = field(init=False, default=None, repr=False)
     _known_hosts_path: c_char_p | None = field(init=False, default=None, repr=False)
     _proxy_jump_host: c_char_p | None = field(init=False, default=None, repr=False)
     _proxy_jump_username: c_char_p | None = field(init=False, default=None, repr=False)
@@ -255,6 +265,12 @@ class Ssh2Options(Options):
             N/A
 
         """
+        if self.known_hosts is not None:
+            self._known_hosts = to_c_string(self.known_hosts)
+
+            options.contents.transport.ssh2.known_hosts = self._known_hosts
+            options.contents.transport.ssh2.known_hosts_len = c_size_t(len(self.known_hosts))
+
         if self.known_hosts_path is not None:
             self._known_hosts_path = to_c_string(self.known_hosts_path)
 

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -1,0 +1,90 @@
+"""tests.unit.test_options"""
+
+from ctypes import pointer
+
+import pytest
+
+from scrapli.auth import Options as AuthOptions
+from scrapli.ffi_options import DriverOptions
+from scrapli.transport import BinOptions, Ssh2Options
+
+
+@pytest.fixture()
+def driver_options():
+    opts = DriverOptions()
+    return pointer(opts)
+
+
+class TestAuthOptionsPrivateKey:
+    def test_apply_sets_private_key(self, driver_options):
+        auth = AuthOptions(private_key="-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----")
+        auth.apply(options=driver_options)
+
+        assert driver_options.contents.auth.private_key is not None
+        assert driver_options.contents.auth.private_key_len > 0
+
+    def test_apply_does_not_set_private_key_when_none(self, driver_options):
+        auth = AuthOptions(username="admin")
+        auth.apply(options=driver_options)
+
+        assert driver_options.contents.auth.private_key_len == 0
+
+    def test_apply_sets_both_private_key_and_path(self, driver_options):
+        auth = AuthOptions(
+            private_key="key-content",
+            private_key_path="/home/user/.ssh/id_rsa",
+        )
+        auth.apply(options=driver_options)
+
+        assert driver_options.contents.auth.private_key_len > 0
+        assert driver_options.contents.auth.private_key_path_len > 0
+
+
+class TestBinOptionsKnownHosts:
+    def test_apply_sets_known_hosts(self, driver_options):
+        transport = BinOptions(known_hosts="host.example.com ssh-rsa AAAA...")
+        transport.apply(options=driver_options)
+
+        assert driver_options.contents.transport.bin.known_hosts is not None
+        assert driver_options.contents.transport.bin.known_hosts_len > 0
+
+    def test_apply_does_not_set_known_hosts_when_none(self, driver_options):
+        transport = BinOptions()
+        transport.apply(options=driver_options)
+
+        assert driver_options.contents.transport.bin.known_hosts_len == 0
+
+    def test_apply_sets_both_known_hosts_and_path(self, driver_options):
+        transport = BinOptions(
+            known_hosts="host.example.com ssh-rsa AAAA...",
+            known_hosts_path="/home/user/.ssh/known_hosts",
+        )
+        transport.apply(options=driver_options)
+
+        assert driver_options.contents.transport.bin.known_hosts_len > 0
+        assert driver_options.contents.transport.bin.known_hosts_path_len > 0
+
+
+class TestSsh2OptionsKnownHosts:
+    def test_apply_sets_known_hosts(self, driver_options):
+        transport = Ssh2Options(known_hosts="host.example.com ssh-rsa AAAA...")
+        transport.apply(options=driver_options)
+
+        assert driver_options.contents.transport.ssh2.known_hosts is not None
+        assert driver_options.contents.transport.ssh2.known_hosts_len > 0
+
+    def test_apply_does_not_set_known_hosts_when_none(self, driver_options):
+        transport = Ssh2Options()
+        transport.apply(options=driver_options)
+
+        assert driver_options.contents.transport.ssh2.known_hosts_len == 0
+
+    def test_apply_sets_both_known_hosts_and_path(self, driver_options):
+        transport = Ssh2Options(
+            known_hosts="host.example.com ssh-rsa AAAA...",
+            known_hosts_path="/home/user/.ssh/known_hosts",
+        )
+        transport.apply(options=driver_options)
+
+        assert driver_options.contents.transport.ssh2.known_hosts_len > 0
+        assert driver_options.contents.transport.ssh2.known_hosts_path_len > 0


### PR DESCRIPTION
## Summary
- Add `private_key` field to auth options for in-memory private key content (tried before file-based auth)
- Add `known_hosts` field to bin and ssh2 transport options for in-memory known_hosts content
- Struct field ordering matches libscrapli `feat/inmemory-keys` branch (`04a4d64`)

## Test plan
- [ ] Verify struct field ordering matches libscrapli FFIOptions
- [ ] Test with in-memory private key content
- [ ] Test with in-memory known_hosts content for both bin and ssh2 transports