### PR TITLE
feat: add failure indicator to raisecom definition

### DIFF
--- a/scrapli/definitions/raisecom_ros.yaml
+++ b/scrapli/definitions/raisecom_ros.yaml
@@ -31,6 +31,7 @@ modes:
               input: 'end'
 failure_indicators:
   - 'Error input in the position marked by ''^''.'
+  - 'Error input in the position market by ''^''.'
   - 'Ambiguous input in the position marked by ''^'''
   - '%  Incomplete command.'
 on_open_instructions:


### PR DESCRIPTION
Came across this when testing `result.failed` on a ISCOM2948GF-4C-AC/D running REAP_1.2.3921_20181221. Seems like Raisecom has made a typo 😅.

```
switch#show version

Product Name: ISCOM2948GF-4C-AC/D 
Hardware Version: A.04 
Software Version: REAP_1.2.3921_20181221
PCB Version: A.1
CPLD Version: 1.1
REAP Version: 1.0
Bootstrap Version: 5.2.1
Compiled Dec 21 2018, 10:43:43

System MacAddress: A86D.5F3C.4F89
Serial number: 101622000104S22519S0021G
128 M   bytes  DRAM
32  M   bytes  Flash Memory

System uptime is 0 days, 5 hours, 37 minutes

switch#show versionn
show versionn
            ^
Error input in the position market by '^'.
switch#
```